### PR TITLE
Add casting of strings to TEXT for pg filters

### DIFF
--- a/src/logicblocks/event/db/postgres.py
+++ b/src/logicblocks/event/db/postgres.py
@@ -137,9 +137,18 @@ class SortColumn:
 class Value:
     value: Any
     wrapper: LiteralString | None = None
+    cast_to_type: LiteralString | None = None
 
     def build_fragment(self) -> ParameterisedQueryFragment:
         operand_sql = sql.SQL("%s")
+        if self.cast_to_type is not None:
+            operand_sql = (
+                sql.SQL("CAST(")
+                + operand_sql
+                + sql.SQL(" AS {type})").format(
+                    type=sql.SQL(self.cast_to_type)
+                )
+            )
         if self.wrapper is not None:
             operand_sql = (
                 sql.SQL("{wrapper}(").format(wrapper=sql.SQL(self.wrapper))

--- a/src/logicblocks/event/projection/store/adapters/postgres.py
+++ b/src/logicblocks/event/projection/store/adapters/postgres.py
@@ -114,6 +114,9 @@ def filter_clause_applicator(
             else Value(
                 filter.value,
                 wrapper="to_jsonb" if filter.path.is_nested() else None,
+                cast_to_type="TEXT"
+                if filter.path.is_nested() and type(filter.value) is str
+                else None,
             )
         )
     )

--- a/tests/unit/logicblocks/event/projection/store/adapters/test_postgres.py
+++ b/tests/unit/logicblocks/event/projection/store/adapters/test_postgres.py
@@ -117,6 +117,29 @@ class TestPostgresQueryConverterQueryConversion:
         )
 
     @pytest.mark.parametrize("query_type", [Lookup, Search])
+    def test_converts_single_string_filter_query_on_nested_attribute(
+        self, query_type
+    ):
+        converter = query_converter_with_default_clause_converters()
+        query = query_type(
+            filters=[
+                FilterClause(
+                    operator=Operator.EQUAL,
+                    path=Path("state", "value"),
+                    value="test",
+                )
+            ]
+        )
+
+        converted = converter.convert_query(query)
+
+        assert parameterised_query_to_string(converted) == (
+            'SELECT * FROM "projections" '
+            "WHERE \"state\"#>'{value}' = to_jsonb(CAST(%s AS TEXT))",
+            ["test"],
+        )
+
+    @pytest.mark.parametrize("query_type", [Lookup, Search])
     def test_converts_multiple_filter_query_on_nested_attributes(
         self, query_type
     ):


### PR DESCRIPTION
Currently the conversion to JSONB doesn't support strings as Postgres doesn't know what the datatype is. This PR assumes strings should be casted to TEXT.