### PR TITLE
Introduce IN operator for projection store queries

### DIFF
--- a/src/logicblocks/event/db/postgres.py
+++ b/src/logicblocks/event/db/postgres.py
@@ -114,6 +114,7 @@ class Operator(StrEnum):
     GREATER_THAN_OR_EQUAL = ">="
     LESS_THAN = "<"
     LESS_THAN_OR_EQUAL = "<="
+    IN = "IN"
 
 
 class SetOperationMode(StrEnum):

--- a/src/logicblocks/event/projection/store/adapters/in_memory.py
+++ b/src/logicblocks/event/projection/store/adapters/in_memory.py
@@ -87,22 +87,24 @@ def filter_clause_converter(
     clause: FilterClause,
 ) -> InMemoryProjectionResultSetTransformer:
     def matches(projection: Projection[Mapping[str, Any]]) -> bool:
-        expected_value = clause.value
-        actual_value = lookup_projection_path(projection, clause.path)
+        comparison_value = clause.value
+        resolved_value = lookup_projection_path(projection, clause.path)
 
         match clause.operator:
             case Operator.EQUAL:
-                return actual_value == expected_value
+                return resolved_value == comparison_value
             case Operator.NOT_EQUAL:
-                return not actual_value == expected_value
+                return not resolved_value == comparison_value
             case Operator.GREATER_THAN:
-                return actual_value > expected_value
+                return resolved_value > comparison_value
             case Operator.GREATER_THAN_OR_EQUAL:
-                return actual_value >= expected_value
+                return resolved_value >= comparison_value
             case Operator.LESS_THAN:
-                return actual_value < expected_value
+                return resolved_value < comparison_value
             case Operator.LESS_THAN_OR_EQUAL:
-                return actual_value <= expected_value
+                return resolved_value <= comparison_value
+            case Operator.IN:
+                return resolved_value in comparison_value
             case _:  # pragma: no cover
                 raise ValueError(f"Unknown operator: {clause.operator}.")
 

--- a/src/logicblocks/event/projection/store/query.py
+++ b/src/logicblocks/event/projection/store/query.py
@@ -10,6 +10,7 @@ class Operator(StrEnum):
     GREATER_THAN_OR_EQUAL = "greater_than_or_equal"
     LESS_THAN = "less_than"
     LESS_THAN_OR_EQUAL = "less_than_or_equal"
+    IN = "in"
 
 
 class SortOrder(StrEnum):

--- a/tests/unit/logicblocks/event/projection/store/adapters/test_in_memory.py
+++ b/tests/unit/logicblocks/event/projection/store/adapters/test_in_memory.py
@@ -870,3 +870,37 @@ class TestInMemoryQueryConverterDefaultClauseConverters:
         )
 
         assert results == []
+
+    def test_filter_on_value_in_list(self):
+        registry = InMemoryQueryConverter().with_default_clause_converters()
+
+        value_to_filter_1 = data.random_ascii_alphanumerics_string(10)
+        value_to_filter_2 = data.random_ascii_alphanumerics_string(10)
+        other_value = data.random_ascii_alphanumerics_string(10)
+        clause = FilterClause(
+            Operator.IN,
+            Path("state", "value_2"),
+            [value_to_filter_1, value_to_filter_2],
+        )
+
+        transformer = registry.convert_clause(clause)
+
+        projection_1 = (
+            MappingProjectionBuilder()
+            .with_state({"value_1": 5, "value_2": value_to_filter_1})
+            .build()
+        )
+        projection_2 = (
+            MappingProjectionBuilder()
+            .with_state({"value_1": 10, "value_2": value_to_filter_2})
+            .build()
+        )
+        projection_3 = (
+            MappingProjectionBuilder()
+            .with_state({"value_1": 15, "value_2": other_value})
+            .build()
+        )
+
+        results = transformer([projection_1, projection_2, projection_3])
+
+        assert results == [projection_1, projection_2]


### PR DESCRIPTION
Adding the IN operator to allow querying for projections where an attribute (in particular when nested in a JSONB) is one out of several values.