### PR TITLE
Introduce CONTAINS operator for projection store queries

### DIFF
--- a/src/logicblocks/event/db/postgres.py
+++ b/src/logicblocks/event/db/postgres.py
@@ -115,6 +115,7 @@ class Operator(StrEnum):
     LESS_THAN = "<"
     LESS_THAN_OR_EQUAL = "<="
     IN = "IN"
+    CONTAINS = "@>"
 
 
 class SetOperationMode(StrEnum):

--- a/src/logicblocks/event/projection/store/adapters/in_memory.py
+++ b/src/logicblocks/event/projection/store/adapters/in_memory.py
@@ -102,6 +102,8 @@ def filter_clause_converter(
                 return resolved_value <= comparison_value
             case Operator.IN:
                 return resolved_value in comparison_value
+            case Operator.CONTAINS:
+                return comparison_value in resolved_value
             case _:  # pragma: no cover
                 raise ValueError(f"Unknown operator: {clause.operator}.")
 

--- a/src/logicblocks/event/projection/store/adapters/postgres.py
+++ b/src/logicblocks/event/projection/store/adapters/postgres.py
@@ -96,6 +96,7 @@ operator_for_query_operator_map = {
     Operator.GREATER_THAN: DBOperator.GREATER_THAN,
     Operator.GREATER_THAN_OR_EQUAL: DBOperator.GREATER_THAN_OR_EQUAL,
     Operator.IN: DBOperator.IN,
+    Operator.CONTAINS: DBOperator.CONTAINS,
 }
 
 

--- a/src/logicblocks/event/projection/store/query.py
+++ b/src/logicblocks/event/projection/store/query.py
@@ -11,6 +11,7 @@ class Operator(StrEnum):
     LESS_THAN = "less_than"
     LESS_THAN_OR_EQUAL = "less_than_or_equal"
     IN = "in"
+    CONTAINS = "contains"
 
 
 class SortOrder(StrEnum):

--- a/tests/unit/logicblocks/event/projection/store/adapters/test_in_memory.py
+++ b/tests/unit/logicblocks/event/projection/store/adapters/test_in_memory.py
@@ -903,3 +903,41 @@ class TestInMemoryQueryConverterDefaultClauseConverters:
         results = transformer([projection_1, projection_2, projection_3])
 
         assert results == [projection_1, projection_2]
+
+    def test_filter_on_list_contains_value(self):
+        registry = InMemoryQueryConverter().with_default_clause_converters()
+
+        value_to_filter = data.random_ascii_alphanumerics_string(10)
+        other_value1 = data.random_ascii_alphanumerics_string(10)
+        other_value2 = data.random_ascii_alphanumerics_string(10)
+        clause = FilterClause(
+            Operator.CONTAINS,
+            Path("state", "value_2"),
+            value_to_filter,
+        )
+
+        transformer = registry.convert_clause(clause)
+
+        projection_1 = (
+            MappingProjectionBuilder()
+            .with_state({"value_1": 5, "value_2": [other_value1]})
+            .build()
+        )
+        projection_2 = (
+            MappingProjectionBuilder()
+            .with_state(
+                {"value_1": 15, "value_2": [other_value1, other_value2]}
+            )
+            .build()
+        )
+        projection_3 = (
+            MappingProjectionBuilder()
+            .with_state(
+                {"value_1": 25, "value_2": [other_value1, value_to_filter]}
+            )
+            .build()
+        )
+
+        results = transformer([projection_1, projection_2, projection_3])
+
+        assert results == [projection_3]


### PR DESCRIPTION
Adding the CONTAINS operator to allow querying for projections where an array contains a specific value.