### PR TITLE
Make position_is work with empty stream

### DIFF
--- a/src/logicblocks/event/store/conditions.py
+++ b/src/logicblocks/event/store/conditions.py
@@ -146,10 +146,11 @@ NoCondition = _NoCondition()
 
 @dataclass(frozen=True)
 class PositionIsCondition(WriteCondition):
-    position: int
+    position: int | None
 
     def assert_met_by(self, *, last_event: StoredEvent[Any, Any] | None):
-        if last_event is None or last_event.position != self.position:
+        latest_position = last_event.position if last_event else None
+        if latest_position != self.position:
             raise UnmetWriteConditionError("unexpected stream position")
 
 
@@ -160,7 +161,7 @@ class EmptyStreamCondition(WriteCondition):
             raise UnmetWriteConditionError("stream is not empty")
 
 
-def position_is(position: int) -> WriteCondition:
+def position_is(position: int | None) -> WriteCondition:
     return PositionIsCondition(position=position)
 
 


### PR DESCRIPTION
I don't think the `position_is` condition should fail when writing to an empty stream.

Example case (apologies for the weird pseudo-code): 

```
category = 'dictionary'
stream = 'english-dictionary'

process=1; time = t1
projection: get current set of words to check we're not writing duplicates
publish: 
   {name = 'word-added', payload='Aardvark'},
   {name = 'word-added', payload='Apple'}
conditions: `position_is(projection.metadata.position)`

process=2; time = t1
projection: get current set of words to check we're not writing duplicates
publish: 
   {name = 'word-added', payload='Antelope'},
conditions: `position_is(projection.metadata.position)`
```

One of these processes should fail if they run concurrently - one writes before the other, causing the projection that the other is relying on to be out-of-date.

However at present both of them will fail if the stream is empty.

---------------------------------------------

If @CorinChappy gets his condition combinator stuff in, then potentially another way of addressing this could be something like: 

condition: `or(position_is(projection.metadata.position), stream_is_empty()`