### PR TITLE
Use new default subscriber_id for each make_subscriber call

### DIFF
--- a/src/logicblocks/event/processing/consumers/subscription.py
+++ b/src/logicblocks/event/processing/consumers/subscription.py
@@ -19,12 +19,13 @@ from .types import EventConsumer, EventProcessor
 def make_subscriber(
     *,
     subscriber_group: str,
-    subscriber_id: str = uuid4().hex,
+    subscriber_id: str | None,
     subscription_request: EventSourceIdentifier,
     subscriber_state_category: EventCategory,
     subscriber_state_persistence_interval: EventCount = EventCount(100),
     event_processor: EventProcessor,
 ) -> "EventSubscriptionConsumer":
+    subscriber_id = subscriber_id or uuid4().hex
     state_store = EventConsumerStateStore(
         category=subscriber_state_category,
         persistence_interval=subscriber_state_persistence_interval,


### PR DESCRIPTION
Argument defaults are evaluated at the point that a function is defined, so if something calls `make_subscriber` multiple times, without providing a value for `subscriber_id`, each subscriber will have the same ID.

This fixes this issue so a fresh subscriber ID is constructed for each subscriber, if the subscriber_id is not provided.