### PR TITLE
temporarily set test batch size to 1, while we figure out a reliable …

### DIFF
--- a/tests/integration/logicblocks/event/store/adapters/test_postgres.py
+++ b/tests/integration/logicblocks/event/store/adapters/test_postgres.py
@@ -139,7 +139,7 @@ class TestPostgresEventStorageAdapterCommonCases(EventStorageAdapterCases):
         return PostgresEventStorageAdapter(
             connection_source=self.pool,
             serialisation_guarantee=serialisation_guarantee,
-            max_insert_batch_size=2,
+            max_insert_batch_size=1,
         )
 
     async def clear_storage(self) -> None:


### PR DESCRIPTION
…way to test this
This is failing in CI - but because the test hasn't triggered the somewhat non-deterministic scenario it's expecting to see.