### PR TITLE
add regex-matches to query

### DIFF
--- a/src/logicblocks/event/persistence/postgres/query.py
+++ b/src/logicblocks/event/persistence/postgres/query.py
@@ -175,6 +175,7 @@ class Operator(StrEnum):
     LESS_THAN_OR_EQUAL = "<="
     IN = "IN"
     CONTAINS = "@>"
+    REGEX_MATCHES = "~"
 
 
 class SetQuantifier(StrEnum):
@@ -285,6 +286,9 @@ class Condition(Expression):
 
     def less_than_or_equal_to(self) -> Self:
         return self.operator(Operator.LESS_THAN_OR_EQUAL)
+
+    def regex_matches(self):
+        return self.operator(Operator.REGEX_MATCHES)
 
     @staticmethod
     def _operand_fragment(

--- a/tests/unit/logicblocks/event/persistence/postgres/test_query.py
+++ b/tests/unit/logicblocks/event/persistence/postgres/test_query.py
@@ -499,6 +499,20 @@ class TestCondition:
             [1, 1],
         )
 
+    def test_regex_matches_condition(self):
+        condition = (
+            Condition()
+            .left(ColumnReference(field="id"))
+            .regex_matches()
+            .right(Constant("123.*"))
+            .to_fragment()
+        )
+
+        assert parameterised_query_fragment_to_string(condition) == (
+            '"id" ~ %s',
+            ["123.*"],
+        )
+
 
 class TestQuerySelect:
     def test_allows_selecting_all_columns_from_single_table(self):


### PR DESCRIPTION
Add regex-matches to query to allow wildcard querying on fields.
I think it probably also makes senses to add more specific text comparison methods that can be optimised a little better (and are more likely to be consistent across persistent stores), but I'd like to see how this performs on real data first.