### PR TITLE
Collapse EventStoreEventSourceFactory classes

### DIFF
--- a/changelog.d/20250611_175412_johncowie_collapse_event_store_event_source_factories.md
+++ b/changelog.d/20250611_175412_johncowie_collapse_event_store_event_source_factories.md
@@ -1,0 +1,7 @@
+### Removed 
+
+- `PostgresEventStoreEventSourceFactory` and `InMemoryEventStoreEventSourceFactory` - usages of both can be replaced with `EventStoreEventSourceFactory`
+
+### Changed
+
+- `EventStorageAdapter` adapter argument can now optionally be provided to factories for building postgres event-brokers, in the case where you want to build a postgres backed event-broker but use an event-store with a different persistence backend.

--- a/src/logicblocks/event/processing/broker/factories.py
+++ b/src/logicblocks/event/processing/broker/factories.py
@@ -7,7 +7,7 @@ from psycopg_pool import AsyncConnectionPool
 
 from logicblocks.event.persistence.postgres import ConnectionSettings
 from logicblocks.event.store import (
-    InMemoryEventStorageAdapter,
+    EventStorageAdapter,
 )
 
 from .base import EventBroker
@@ -53,31 +53,33 @@ StorageType.Postgres = _PostgresStorageType
 
 class InMemoryDistributedBrokerParams(TypedDict):
     settings: DistributedEventBrokerSettings
-    adapter: InMemoryEventStorageAdapter
+    adapter: EventStorageAdapter
 
 
 class PostgresDistributedBrokerParams(TypedDict):
     connection_settings: ConnectionSettings
     connection_pool: AsyncConnectionPool[AsyncConnection]
     settings: DistributedEventBrokerSettings
+    adapter: EventStorageAdapter | None
 
 
 class InMemorySingletonBrokerParams(TypedDict):
     settings: SingletonEventBrokerSettings
-    adapter: InMemoryEventStorageAdapter
+    adapter: EventStorageAdapter
 
 
 class PostgresSingletonBrokerParams(TypedDict):
     connection_settings: ConnectionSettings
     connection_pool: AsyncConnectionPool[AsyncConnection]
     settings: SingletonEventBrokerSettings
+    adapter: EventStorageAdapter | None
 
 
 class CombinedBrokerParams(TypedDict, total=False):
     settings: DistributedEventBrokerSettings | SingletonEventBrokerSettings
-    adapter: InMemoryEventStorageAdapter
     connection_settings: ConnectionSettings
     connection_pool: AsyncConnectionPool[AsyncConnection]
+    adapter: EventStorageAdapter | None
 
 
 @overload
@@ -147,7 +149,7 @@ def make_event_broker(
 def make_in_memory_event_broker(
     node_id: str,
     settings: DistributedEventBrokerSettings,
-    adapter: InMemoryEventStorageAdapter,
+    adapter: EventStorageAdapter,
 ) -> EventBroker:
     return make_in_memory_distributed_event_broker(node_id, settings, adapter)
 

--- a/src/logicblocks/event/processing/broker/strategies/singleton/factories.py
+++ b/src/logicblocks/event/processing/broker/strategies/singleton/factories.py
@@ -2,10 +2,7 @@ from psycopg import AsyncConnection
 from psycopg_pool import AsyncConnectionPool
 
 from logicblocks.event.persistence.postgres import ConnectionSettings
-from logicblocks.event.sources import (
-    InMemoryEventStoreEventSourceFactory,
-    PostgresEventStoreEventSourceFactory,
-)
+from logicblocks.event.sources import EventStoreEventSourceFactory
 from logicblocks.event.store import (
     InMemoryEventStorageAdapter,
     PostgresEventStorageAdapter,
@@ -26,9 +23,7 @@ class InMemorySingletonEventBrokerBuilder(
         self, adapter: InMemoryEventStorageAdapter
     ) -> SingletonEventBrokerDependencies:
         return SingletonEventBrokerDependencies(
-            event_source_factory=InMemoryEventStoreEventSourceFactory(
-                adapter=adapter
-            )
+            event_source_factory=EventStoreEventSourceFactory(adapter=adapter)
         )
 
 
@@ -43,7 +38,7 @@ class PostgresSingletonEventBrokerBuilder(
         connection_pool: AsyncConnectionPool[AsyncConnection],
     ) -> SingletonEventBrokerDependencies:
         return SingletonEventBrokerDependencies(
-            event_source_factory=PostgresEventStoreEventSourceFactory(
+            event_source_factory=EventStoreEventSourceFactory(
                 adapter=PostgresEventStorageAdapter(
                     connection_source=connection_pool
                 )

--- a/src/logicblocks/event/sources/__init__.py
+++ b/src/logicblocks/event/sources/__init__.py
@@ -3,10 +3,4 @@ from .factory import EventSourceFactory as EventSourceFactory
 from .factory import (
     EventStoreEventSourceFactory as EventStoreEventSourceFactory,
 )
-from .factory import (
-    InMemoryEventStoreEventSourceFactory as InMemoryEventStoreEventSourceFactory,
-)
-from .factory import (
-    PostgresEventStoreEventSourceFactory as PostgresEventStoreEventSourceFactory,
-)
 from .memory import InMemoryEventSource as InMemoryEventSource

--- a/src/logicblocks/event/sources/factory/__init__.py
+++ b/src/logicblocks/event/sources/factory/__init__.py
@@ -1,8 +1,2 @@
 from .base import EventSourceFactory as EventSourceFactory
 from .store import EventStoreEventSourceFactory as EventStoreEventSourceFactory
-from .store import (
-    InMemoryEventStoreEventSourceFactory as InMemoryEventStoreEventSourceFactory,
-)
-from .store import (
-    PostgresEventStoreEventSourceFactory as PostgresEventStoreEventSourceFactory,
-)

--- a/src/logicblocks/event/sources/factory/store.py
+++ b/src/logicblocks/event/sources/factory/store.py
@@ -1,4 +1,3 @@
-from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any, MutableMapping, Self
 
@@ -7,8 +6,6 @@ from logicblocks.event.store import (
     EventSource,
     EventStorageAdapter,
     EventStream,
-    InMemoryEventStorageAdapter,
-    PostgresEventStorageAdapter,
 )
 from logicblocks.event.types import (
     CategoryIdentifier,
@@ -36,22 +33,19 @@ type EventSourceConstructor[I: EventSourceIdentifier] = Callable[
 ]
 
 
-class EventStoreEventSourceFactory(
-    EventSourceFactory[EventStorageAdapter], ABC
-):
-    def __init__(self):
+class EventStoreEventSourceFactory(EventSourceFactory[EventStorageAdapter]):
+    def __init__(self, adapter: EventStorageAdapter):
         self._constructors: MutableMapping[
             type[EventSourceIdentifier],
             EventSourceConstructor[Any],
         ] = {}
-
+        self._adapter = adapter
         self.register_constructor(CategoryIdentifier, construct_event_category)
         self.register_constructor(StreamIdentifier, construct_event_stream)
 
     @property
-    @abstractmethod
     def storage_adapter(self) -> EventStorageAdapter:
-        raise NotImplementedError()
+        return self._adapter
 
     def register_constructor[I: EventSourceIdentifier](
         self,
@@ -67,23 +61,3 @@ class EventStoreEventSourceFactory(
         return self._constructors[type(identifier)](
             identifier, self.storage_adapter
         )
-
-
-class InMemoryEventStoreEventSourceFactory(EventStoreEventSourceFactory):
-    def __init__(self, adapter: InMemoryEventStorageAdapter):
-        super().__init__()
-        self._adapter = adapter
-
-    @property
-    def storage_adapter(self) -> EventStorageAdapter:
-        return self._adapter
-
-
-class PostgresEventStoreEventSourceFactory(EventStoreEventSourceFactory):
-    def __init__(self, adapter: PostgresEventStorageAdapter):
-        super().__init__()
-        self._adapter = adapter
-
-    @property
-    def storage_adapter(self) -> EventStorageAdapter:
-        return self._adapter

--- a/tests/unit/logicblocks/event/processing/brokers/strategies/distributed/test_observer.py
+++ b/tests/unit/logicblocks/event/processing/brokers/strategies/distributed/test_observer.py
@@ -18,9 +18,7 @@ from logicblocks.event.processing.broker.subscribers import (
     EventSubscriberStore,
     InMemoryEventSubscriberStore,
 )
-from logicblocks.event.sources import (
-    InMemoryEventStoreEventSourceFactory,
-)
+from logicblocks.event.sources import EventStoreEventSourceFactory
 from logicblocks.event.store.adapters import InMemoryEventStorageAdapter
 from logicblocks.event.store.adapters.base import EventStorageAdapter
 from logicblocks.event.store.store import EventCategory
@@ -112,7 +110,7 @@ def make_observer(
     logger = CapturingLogger.create()
     subscription_difference = EventSubscriptionDifference()
     event_storage_adapter = InMemoryEventStorageAdapter()
-    event_source_factory = InMemoryEventStoreEventSourceFactory(
+    event_source_factory = EventStoreEventSourceFactory(
         adapter=event_storage_adapter
     )
 

--- a/tests/unit/logicblocks/event/processing/brokers/strategies/singleton/test_broker.py
+++ b/tests/unit/logicblocks/event/processing/brokers/strategies/singleton/test_broker.py
@@ -22,7 +22,7 @@ from logicblocks.event.processing.broker.subscribers import (
 )
 from logicblocks.event.sources import (
     EventSourceFactory,
-    InMemoryEventStoreEventSourceFactory,
+    EventStoreEventSourceFactory,
 )
 from logicblocks.event.store import EventSource
 from logicblocks.event.store.adapters import (
@@ -100,7 +100,7 @@ def make_event_broker_with_real_dependencies(
 
     event_subscriber_store = InMemoryEventSubscriberStore()
     event_storage_adapter = InMemoryEventStorageAdapter()
-    event_source_factory = InMemoryEventStoreEventSourceFactory(
+    event_source_factory = EventStoreEventSourceFactory(
         adapter=event_storage_adapter
     )
 

--- a/tests/unit/logicblocks/event/sources/test_factory.py
+++ b/tests/unit/logicblocks/event/sources/test_factory.py
@@ -1,10 +1,7 @@
 import pytest
 
 from logicblocks.event.persistence.postgres import ConnectionSettings
-from logicblocks.event.sources import (
-    InMemoryEventStoreEventSourceFactory,
-    PostgresEventStoreEventSourceFactory,
-)
+from logicblocks.event.sources import EventStoreEventSourceFactory
 from logicblocks.event.store import (
     EventCategory,
     EventStream,
@@ -35,22 +32,16 @@ def make_postgres_event_storage_adapter() -> PostgresEventStorageAdapter:
 
 
 @pytest.mark.parametrize(
-    "adapter_factory,factory_class",
+    "adapter_factory",
     [
-        (
-            make_in_memory_event_storage_adapter,
-            InMemoryEventStoreEventSourceFactory,
-        ),
-        (
-            make_postgres_event_storage_adapter,
-            PostgresEventStoreEventSourceFactory,
-        ),
+        make_in_memory_event_storage_adapter,
+        make_postgres_event_storage_adapter,
     ],
 )
 class TestEventStoreEventSourceFactoryDefaultConstructors:
-    def test_constructs_event_category(self, adapter_factory, factory_class):
+    def test_constructs_event_category(self, adapter_factory):
         adapter = adapter_factory()
-        factory = factory_class(adapter)
+        factory = EventStoreEventSourceFactory(adapter)
 
         identifier = CategoryIdentifier(
             category=data.random_event_category_name()
@@ -60,9 +51,9 @@ class TestEventStoreEventSourceFactoryDefaultConstructors:
 
         assert source == EventCategory(adapter, identifier)
 
-    def test_constructs_event_stream(self, adapter_factory, factory_class):
+    def test_constructs_event_stream(self, adapter_factory):
         adapter = adapter_factory()
-        factory = factory_class(adapter)
+        factory = EventStoreEventSourceFactory(adapter)
 
         identifier = StreamIdentifier(
             category=data.random_event_category_name(),


### PR DESCRIPTION
- Collapses `PostgresEventStoreEventSourceFactory` and `InMemoryEventStoreEventSourceFactory` into `EventStoreEventSourceFactory` as they have the same implementation.
- Adds support for overriding the event-store-adapter in the event-broker factories.