### PR TITLE
adding count method to projection store

### DIFF
--- a/src/logicblocks/event/projection/store/adapters/base.py
+++ b/src/logicblocks/event/projection/store/adapters/base.py
@@ -47,3 +47,7 @@ class ProjectionStorageAdapter[
         metadata_type: type[Metadata] = JsonValueType,
     ) -> Sequence[Projection[State, Metadata]]:
         raise NotImplementedError()
+
+    @abstractmethod
+    async def count(self) -> int:
+        raise NotImplementedError()

--- a/src/logicblocks/event/projection/store/adapters/base.py
+++ b/src/logicblocks/event/projection/store/adapters/base.py
@@ -49,5 +49,5 @@ class ProjectionStorageAdapter[
         raise NotImplementedError()
 
     @abstractmethod
-    async def count(self) -> int:
+    async def count(self, *, search: CollectionQuery) -> int:
         raise NotImplementedError()

--- a/src/logicblocks/event/projection/store/adapters/memory.py
+++ b/src/logicblocks/event/projection/store/adapters/memory.py
@@ -119,3 +119,6 @@ class InMemoryProjectionStorageAdapter[
             deserialise_projection(projection, state_type, metadata_type)
             for projection in (await self._find_raw(search))
         ]
+
+    async def count(self) -> int:
+        return len(self._projections)

--- a/src/logicblocks/event/projection/store/adapters/memory.py
+++ b/src/logicblocks/event/projection/store/adapters/memory.py
@@ -120,5 +120,5 @@ class InMemoryProjectionStorageAdapter[
             for projection in (await self._find_raw(search))
         ]
 
-    async def count(self) -> int:
-        return len(self._projections)
+    async def count(self, *, search: CollectionQuery) -> int:
+        return len(await self._find_raw(search))

--- a/src/logicblocks/event/projection/store/adapters/postgres.py
+++ b/src/logicblocks/event/projection/store/adapters/postgres.py
@@ -193,3 +193,14 @@ class PostgresProjectionStorageAdapter[
                     )
                     for projection in projections
                 ]
+
+    async def count(self) -> int:
+        query = sql.SQL("SELECT COUNT(*) FROM {0}").format(
+            sql.Identifier(self.table_settings.table_name)
+        )
+        async with self.connection_pool.connection() as connection:
+            async with connection.cursor() as cursor:
+                results = await cursor.execute(query)
+                row = await results.fetchone()
+                return row[0] if row else 0
+

--- a/src/logicblocks/event/projection/store/adapters/postgres.py
+++ b/src/logicblocks/event/projection/store/adapters/postgres.py
@@ -197,7 +197,9 @@ class PostgresProjectionStorageAdapter[
     async def count(self, *, search: CollectionQuery) -> int:
         inner_query = self.query_converter.convert_query(search)
         query = (
-            sql.SQL("SELECT COUNT(*) FROM ({0}) AS subquery").format(inner_query[0]),
+            sql.SQL("SELECT COUNT(*) FROM ({0}) AS subquery").format(
+                inner_query[0]
+            ),
             inner_query[1],
         )
         async with self.connection_pool.connection() as connection:
@@ -205,4 +207,3 @@ class PostgresProjectionStorageAdapter[
                 results = await cursor.execute(*query)
                 row = await results.fetchone()
                 return row[0] if row else 0
-

--- a/src/logicblocks/event/projection/store/adapters/postgres.py
+++ b/src/logicblocks/event/projection/store/adapters/postgres.py
@@ -194,13 +194,15 @@ class PostgresProjectionStorageAdapter[
                     for projection in projections
                 ]
 
-    async def count(self) -> int:
-        query = sql.SQL("SELECT COUNT(*) FROM {0}").format(
-            sql.Identifier(self.table_settings.table_name)
+    async def count(self, *, search: CollectionQuery) -> int:
+        inner_query = self.query_converter.convert_query(search)
+        query = (
+            sql.SQL("SELECT COUNT(*) FROM ({0}) AS subquery").format(inner_query[0]),
+            inner_query[1],
         )
         async with self.connection_pool.connection() as connection:
             async with connection.cursor() as cursor:
-                results = await cursor.execute(query)
+                results = await cursor.execute(*query)
                 row = await results.fetchone()
                 return row[0] if row else 0
 

--- a/tests/shared/logicblocks/event/testcases/projection/store/adapters.py
+++ b/tests/shared/logicblocks/event/testcases/projection/store/adapters.py
@@ -943,7 +943,69 @@ class FindManyCases(Base, ABC):
         assert located == [projection_2, projection_3]
 
 
+class CountCases(Base, ABC):
+    async def test_returns_zero_when_no_projections(self):
+        adapter = self.construct_storage_adapter()
+
+        total = await adapter.count()
+
+        assert total == 0
+
+    async def test_returns_count_of_single_projection(self):
+        adapter = self.construct_storage_adapter()
+
+        projection = ThingProjectionBuilder().build()
+        await adapter.save(projection=projection)
+
+        total = await adapter.count()
+
+        assert total == 1
+
+    async def test_returns_count_of_multiple_projections(self):
+        adapter = self.construct_storage_adapter()
+
+        projection_1 = ThingProjectionBuilder().build()
+        projection_2 = ThingProjectionBuilder().build()
+        projection_3 = ThingProjectionBuilder().build()
+
+        await adapter.save(projection=projection_1)
+        await adapter.save(projection=projection_2)
+        await adapter.save(projection=projection_3)
+
+        total = await adapter.count()
+
+        assert total == 3
+
+    async def test_returns_same_count_when_updating_existing_projection(self):
+        projection_id = data.random_projection_id()
+        projection_name = data.random_projection_name()
+
+        adapter = self.construct_storage_adapter()
+
+        projection_v1 = (
+            ThingProjectionBuilder()
+            .with_id(projection_id)
+            .with_name(projection_name)
+            .with_state(Thing(value_1=5, value_2="first version"))
+            .build()
+        )
+        projection_v2 = (
+            ThingProjectionBuilder()
+            .with_id(projection_id)
+            .with_name(projection_name)
+            .with_state(Thing(value_1=10, value_2="second version"))
+            .build()
+        )
+
+        await adapter.save(projection=projection_v1)
+        await adapter.save(projection=projection_v2)
+
+        total = await adapter.count()
+
+        assert total == 1
+
+
 class ProjectionStorageAdapterCases(
-    SaveCases, FindOneCases, FindManyCases, ABC
+    SaveCases, FindOneCases, FindManyCases, CountCases, ABC
 ):
     pass

--- a/tests/shared/logicblocks/event/testcases/projection/store/adapters.py
+++ b/tests/shared/logicblocks/event/testcases/projection/store/adapters.py
@@ -947,7 +947,7 @@ class CountCases(Base, ABC):
     async def test_returns_zero_when_no_projections(self):
         adapter = self.construct_storage_adapter()
 
-        total = await adapter.count()
+        total = await adapter.count(search=Search())
 
         assert total == 0
 
@@ -957,7 +957,7 @@ class CountCases(Base, ABC):
         projection = ThingProjectionBuilder().build()
         await adapter.save(projection=projection)
 
-        total = await adapter.count()
+        total = await adapter.count(search=Search())
 
         assert total == 1
 
@@ -972,7 +972,7 @@ class CountCases(Base, ABC):
         await adapter.save(projection=projection_2)
         await adapter.save(projection=projection_3)
 
-        total = await adapter.count()
+        total = await adapter.count(search=Search())
 
         assert total == 3
 
@@ -1000,9 +1000,42 @@ class CountCases(Base, ABC):
         await adapter.save(projection=projection_v1)
         await adapter.save(projection=projection_v2)
 
-        total = await adapter.count()
+        total = await adapter.count(search=Search())
 
         assert total == 1
+
+    async def test_returns_count_of_filtered_projections(self):
+        adapter = self.construct_storage_adapter()
+
+        projection_1 = (
+            ThingProjectionBuilder()
+            .with_name("type-a")
+            .with_state(Thing(value_1=1))
+            .build()
+        )
+        projection_2 = (
+            ThingProjectionBuilder()
+            .with_name("type-a")
+            .with_state(Thing(value_1=2))
+            .build()
+        )
+        projection_3 = (
+            ThingProjectionBuilder()
+            .with_name("type-b")
+            .with_state(Thing(value_1=3))
+            .build()
+        )
+
+        await adapter.save(projection=projection_1)
+        await adapter.save(projection=projection_2)
+        await adapter.save(projection=projection_3)
+
+        search = Search(
+            filters=[FilterClause(Operator.EQUAL, Path("name"), "type-a")]
+        )
+        total = await adapter.count(search=search)
+
+        assert total == 2
 
 
 class ProjectionStorageAdapterCases(


### PR DESCRIPTION
This pull request introduces a new method to count the number of projections in projection store adapters and provides comprehensive tests to ensure its correctness across implementations. The main changes include adding the abstract `count` method to the base adapter, implementing it in both the in-memory and Postgres adapters, and expanding the shared test suite to cover various counting scenarios.

### Projection Store Adapter Enhancements

* Added an abstract `count` method to the base adapter interface in `base.py`, requiring all projection store adapters to implement a method that returns the number of projections.
* Implemented the `count` method in the in-memory adapter (`memory.py`), returning the length of the internal projections list.
* Implemented the `count` method in the Postgres adapter (`postgres.py`), executing a SQL query to count the rows in the projections table.

### Testing Improvements

* Added a new `CountCases` test class to the shared adapter test suite (`adapters.py`), covering scenarios such as zero projections, single and multiple projections, and updating existing projections. Integrated these tests into the main test case mixin.