### PR TITLE
Add OffsetPagingConstraint for event pagination

### DIFF
--- a/changelog.d/20260309_130645_adammelin_events_paging_constraint.md
+++ b/changelog.d/20260309_130645_adammelin_events_paging_constraint.md
@@ -1,0 +1,4 @@
+### Added
+
+- Add `OffsetPagingConstraint` query constraint for paginating events while
+  preserving lazy iteration and batching behaviour.

--- a/src/logicblocks/event/sources/constraints.py
+++ b/src/logicblocks/event/sources/constraints.py
@@ -15,5 +15,31 @@ class SequenceNumberAfterConstraint(QueryConstraint):
     sequence_number: int
 
 
+@dataclass(frozen=True)
+class OffsetPagingConstraint(QueryConstraint):
+    page_number: int
+    item_count: int
+
+    def __init__(self, *, page_number: int = 1, item_count: int = 10):
+        if page_number < 1:
+            raise ValueError("page_number must be >= 1")
+        if item_count < 1:
+            raise ValueError("item_count must be >= 1")
+        object.__setattr__(self, "page_number", page_number)
+        object.__setattr__(self, "item_count", item_count)
+
+    @property
+    def offset(self):
+        return (self.page_number - 1) * self.item_count
+
+
 def sequence_number_after(sequence_number: int) -> QueryConstraint:
     return SequenceNumberAfterConstraint(sequence_number=sequence_number)
+
+
+def offset_paging(
+    *, page_number: int = 1, item_count: int = 10
+) -> QueryConstraint:
+    return OffsetPagingConstraint(
+        page_number=page_number, item_count=item_count
+    )

--- a/src/logicblocks/event/sources/memory.py
+++ b/src/logicblocks/event/sources/memory.py
@@ -10,7 +10,11 @@ from logicblocks.event.types import (
 )
 
 from .base import EventSource
-from .constraints import QueryConstraint, QueryConstraintCheck
+from .constraints import (
+    OffsetPagingConstraint,
+    QueryConstraint,
+    QueryConstraintCheck,
+)
 
 
 class InMemoryEventSource[I: EventSourceIdentifier, E: Event](
@@ -47,13 +51,32 @@ class InMemoryEventSource[I: EventSourceIdentifier, E: Event](
     async def iterate(
         self, *, constraints: Set[QueryConstraint] = frozenset()
     ) -> AsyncIterator[E]:
+        paging = None
+        filter_constraints = set()
+        for constraint in constraints:
+            if isinstance(constraint, OffsetPagingConstraint):
+                paging = constraint
+            else:
+                filter_constraints.add(constraint)
+
+        matched = 0
+        skipped = 0
+        offset = paging.offset if paging else 0
+        limit = paging.item_count if paging else None
+
         for event in self._events:
             await asyncio.sleep(0)
             if all(
                 self._constraint_converter.convert(constraint)(event)
-                for constraint in constraints
+                for constraint in filter_constraints
             ):
+                if skipped < offset:
+                    skipped += 1
+                    continue
                 yield event
+                matched += 1
+                if limit is not None and matched >= limit:
+                    return
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, InMemoryEventSource):

--- a/src/logicblocks/event/sources/memory.py
+++ b/src/logicblocks/event/sources/memory.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator, Sequence, Set
 from typing import Any, cast
 
 from logicblocks.event.types import (
+    Applier,
     Converter,
     Event,
     EventSourceIdentifier,
@@ -11,10 +12,21 @@ from logicblocks.event.types import (
 
 from .base import EventSource
 from .constraints import (
-    OffsetPagingConstraint,
     QueryConstraint,
-    QueryConstraintCheck,
 )
+
+
+class InMemoryEventSourceQueryApplier[E: Event](
+    Applier[AsyncIterator[E]], ABC
+):
+    @property
+    @abstractmethod
+    def order(self) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply(self, target: AsyncIterator[E]) -> AsyncIterator[E]:
+        raise NotImplementedError
 
 
 class InMemoryEventSource[I: EventSourceIdentifier, E: Event](
@@ -25,7 +37,7 @@ class InMemoryEventSource[I: EventSourceIdentifier, E: Event](
         events: Sequence[E],
         identifier: I,
         constraint_converter: Converter[
-            QueryConstraint, QueryConstraintCheck[E]
+            QueryConstraint, InMemoryEventSourceQueryApplier[E]
         ]
         | None = None,
     ):
@@ -38,7 +50,7 @@ class InMemoryEventSource[I: EventSourceIdentifier, E: Event](
     @abstractmethod
     def _get_default_constraint_converter(
         self,
-    ) -> Converter[QueryConstraint, QueryConstraintCheck[E]]:
+    ) -> Converter[QueryConstraint, InMemoryEventSourceQueryApplier[E]]:
         raise NotImplementedError
 
     @property
@@ -51,32 +63,25 @@ class InMemoryEventSource[I: EventSourceIdentifier, E: Event](
     async def iterate(
         self, *, constraints: Set[QueryConstraint] = frozenset()
     ) -> AsyncIterator[E]:
-        paging = None
-        filter_constraints = set()
-        for constraint in constraints:
-            if isinstance(constraint, OffsetPagingConstraint):
-                paging = constraint
-            else:
-                filter_constraints.add(constraint)
+        appliers = sorted(
+            (
+                self._constraint_converter.convert(constraint)
+                for constraint in constraints
+            ),
+            key=lambda a: a.order,
+        )
 
-        matched = 0
-        skipped = 0
-        offset = paging.offset if paging else 0
-        limit = paging.item_count if paging else None
-
-        for event in self._events:
-            await asyncio.sleep(0)
-            if all(
-                self._constraint_converter.convert(constraint)(event)
-                for constraint in filter_constraints
-            ):
-                if skipped < offset:
-                    skipped += 1
-                    continue
+        async def base_iterator() -> AsyncIterator[E]:
+            for event in self._events:
+                await asyncio.sleep(0)
                 yield event
-                matched += 1
-                if limit is not None and matched >= limit:
-                    return
+
+        source: AsyncIterator[E] = base_iterator()
+        for applier in appliers:
+            source = applier.apply(source)
+
+        async for event in source:
+            yield event
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, InMemoryEventSource):

--- a/src/logicblocks/event/store/adapters/memory/__init__.py
+++ b/src/logicblocks/event/store/adapters/memory/__init__.py
@@ -1,5 +1,8 @@
 from .adapter import InMemoryEventStorageAdapter as InMemoryEventStorageAdapter
 from .converters import (
+    InMemoryQueryApplier as InMemoryQueryApplier,
+)
+from .converters import (
     TypeRegistryConstraintConverter as InMemoryTypeRegistryConstraintConverter,
 )
 from .locks import MultiLock as MultiLock
@@ -7,6 +10,7 @@ from .types import InMemoryQueryConstraintCheck
 
 __all__ = [
     "InMemoryEventStorageAdapter",
+    "InMemoryQueryApplier",
     "InMemoryQueryConstraintCheck",
     "InMemoryTypeRegistryConstraintConverter",
     "MultiLock",

--- a/src/logicblocks/event/store/adapters/memory/adapter.py
+++ b/src/logicblocks/event/store/adapters/memory/adapter.py
@@ -13,6 +13,10 @@ from uuid import uuid4
 from aiologic import Lock
 
 from logicblocks.event.sources import constraints
+from logicblocks.event.sources.constraints import (
+    OffsetPagingConstraint,
+    QueryConstraint,
+)
 from logicblocks.event.types import (
     CategoryIdentifier,
     Converter,
@@ -329,11 +333,32 @@ class InMemoryEventStorageAdapter(EventStorageAdapter):
     ) -> AsyncIterator[StoredEvent[str, JsonValue]]:
         snapshot = self._db.snapshot()
 
-        async_generator = snapshot.scan_events(target, constraints)
+        paging = None
+        filter_constraints: set[QueryConstraint] = set()
+        for constraint in constraints:
+            if isinstance(constraint, OffsetPagingConstraint):
+                paging = constraint
+            else:
+                filter_constraints.add(constraint)
+
+        matched = 0
+        skipped = 0
+        offset = paging.offset if paging else 0
+        limit = paging.item_count if paging else None
+
+        async_generator = snapshot.scan_events(
+            target, frozenset(filter_constraints)
+        )
         try:
             async for event in async_generator:
                 await asyncio.sleep(0)
+                if skipped < offset:
+                    skipped += 1
+                    continue
                 yield event
+                matched += 1
+                if limit is not None and matched >= limit:
+                    return
         finally:
             if isinstance(async_generator, AsyncGenerator):
                 await async_generator.aclose()

--- a/src/logicblocks/event/store/adapters/memory/adapter.py
+++ b/src/logicblocks/event/store/adapters/memory/adapter.py
@@ -13,10 +13,6 @@ from uuid import uuid4
 from aiologic import Lock
 
 from logicblocks.event.sources import constraints
-from logicblocks.event.sources.constraints import (
-    OffsetPagingConstraint,
-    QueryConstraint,
-)
 from logicblocks.event.types import (
     CategoryIdentifier,
     Converter,
@@ -44,6 +40,7 @@ from ..base import (
     Scannable,
 )
 from .converters import (
+    InMemoryQueryApplier,
     TypeRegistryConditionConverter,
     TypeRegistryConstraintConverter,
     WriteConditionEnforcer,
@@ -62,7 +59,7 @@ class InMemoryEventStorageAdapter(EventStorageAdapter):
         ] = EventSerialisationGuarantee.LOG,
         constraint_converter: Converter[
             constraints.QueryConstraint,
-            constraints.QueryConstraintCheck[StoredEvent],
+            InMemoryQueryApplier,
         ]
         | None = None,
         condition_converter: Converter[WriteCondition, WriteConditionEnforcer]
@@ -89,7 +86,6 @@ class InMemoryEventStorageAdapter(EventStorageAdapter):
             log_index=None,
             category_index=None,
             stream_index=None,
-            constraint_converter=self._constraint_converter,
         )
         self._serialisation_guarantee = serialisation_guarantee
 
@@ -333,32 +329,25 @@ class InMemoryEventStorageAdapter(EventStorageAdapter):
     ) -> AsyncIterator[StoredEvent[str, JsonValue]]:
         snapshot = self._db.snapshot()
 
-        paging = None
-        filter_constraints: set[QueryConstraint] = set()
-        for constraint in constraints:
-            if isinstance(constraint, OffsetPagingConstraint):
-                paging = constraint
-            else:
-                filter_constraints.add(constraint)
-
-        matched = 0
-        skipped = 0
-        offset = paging.offset if paging else 0
-        limit = paging.item_count if paging else None
-
-        async_generator = snapshot.scan_events(
-            target, frozenset(filter_constraints)
+        appliers = sorted(
+            (
+                self._constraint_converter.convert(constraint)
+                for constraint in constraints
+            ),
+            key=lambda a: a.order,
         )
+
+        source: AsyncIterator[StoredEvent[str, JsonValue]] = (
+            snapshot.scan_events(target)
+        )
+        for applier in appliers:
+            source = applier.apply(source)
+
+        async_generator = source
         try:
             async for event in async_generator:
                 await asyncio.sleep(0)
-                if skipped < offset:
-                    skipped += 1
-                    continue
                 yield event
-                matched += 1
-                if limit is not None and matched >= limit:
-                    return
         finally:
             if isinstance(async_generator, AsyncGenerator):
                 await async_generator.aclose()

--- a/src/logicblocks/event/store/adapters/memory/converters.py
+++ b/src/logicblocks/event/store/adapters/memory/converters.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Sequence
+from enum import IntEnum
 from typing import Self
 
 from logicblocks.event.persistence import TypeRegistryConverter
@@ -24,8 +25,10 @@ from ...exceptions import UnmetWriteConditionError
 from .db import InMemoryEventsDBTransaction
 from .types import InMemoryQueryConstraintCheck
 
-FILTER_ORDER = 0
-WINDOW_ORDER = 1
+
+class QueryApplierOrder(IntEnum):
+    FILTER = 0
+    WINDOW = 1
 
 
 class InMemoryQueryApplier(
@@ -40,7 +43,7 @@ class FilteringQueryApplier(InMemoryQueryApplier):
 
     @property
     def order(self) -> int:
-        return FILTER_ORDER
+        return QueryApplierOrder.FILTER
 
     async def apply(
         self, target: AsyncIterator[StoredEvent[str, JsonValue]]
@@ -57,7 +60,7 @@ class OffsetPagingQueryApplier(InMemoryQueryApplier):
 
     @property
     def order(self) -> int:
-        return WINDOW_ORDER
+        return QueryApplierOrder.WINDOW
 
     async def apply(
         self, target: AsyncIterator[StoredEvent[str, JsonValue]]

--- a/src/logicblocks/event/store/adapters/memory/converters.py
+++ b/src/logicblocks/event/store/adapters/memory/converters.py
@@ -1,11 +1,13 @@
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
 from typing import Self
 
 from logicblocks.event.persistence import TypeRegistryConverter
 from logicblocks.event.sources import constraints
+from logicblocks.event.sources.memory import InMemoryEventSourceQueryApplier
 from logicblocks.event.types import (
     Converter,
+    JsonValue,
     StoredEvent,
     StreamIdentifier,
 )
@@ -22,30 +24,84 @@ from ...exceptions import UnmetWriteConditionError
 from .db import InMemoryEventsDBTransaction
 from .types import InMemoryQueryConstraintCheck
 
+FILTER_ORDER = 0
+WINDOW_ORDER = 1
+
+
+class InMemoryQueryApplier(
+    InMemoryEventSourceQueryApplier[StoredEvent[str, JsonValue]], ABC
+):
+    pass
+
+
+class FilteringQueryApplier(InMemoryQueryApplier):
+    def __init__(self, check: InMemoryQueryConstraintCheck):
+        self._check = check
+
+    @property
+    def order(self) -> int:
+        return FILTER_ORDER
+
+    async def apply(
+        self, target: AsyncIterator[StoredEvent[str, JsonValue]]
+    ) -> AsyncIterator[StoredEvent[str, JsonValue]]:
+        async for event in target:
+            if self._check(event):
+                yield event
+
+
+class OffsetPagingQueryApplier(InMemoryQueryApplier):
+    def __init__(self, offset: int, limit: int):
+        self._offset = offset
+        self._limit = limit
+
+    @property
+    def order(self) -> int:
+        return WINDOW_ORDER
+
+    async def apply(
+        self, target: AsyncIterator[StoredEvent[str, JsonValue]]
+    ) -> AsyncIterator[StoredEvent[str, JsonValue]]:
+        skipped = 0
+        matched = 0
+        async for event in target:
+            if skipped < self._offset:
+                skipped += 1
+                continue
+            yield event
+            matched += 1
+            if matched >= self._limit:
+                return
+
 
 class SequenceNumberAfterConstraintConverter(
-    Converter[
-        constraints.SequenceNumberAfterConstraint, InMemoryQueryConstraintCheck
-    ]
+    Converter[constraints.SequenceNumberAfterConstraint, InMemoryQueryApplier]
 ):
     def convert(
         self, item: constraints.SequenceNumberAfterConstraint
-    ) -> InMemoryQueryConstraintCheck:
+    ) -> InMemoryQueryApplier:
         def check(event: StoredEvent) -> bool:
             return event.sequence_number > item.sequence_number
 
-        return check
+        return FilteringQueryApplier(check=check)
+
+
+class OffsetPagingConstraintConverter(
+    Converter[constraints.OffsetPagingConstraint, InMemoryQueryApplier]
+):
+    def convert(
+        self, item: constraints.OffsetPagingConstraint
+    ) -> InMemoryQueryApplier:
+        return OffsetPagingQueryApplier(item.offset, item.item_count)
 
 
 class TypeRegistryConstraintConverter(
-    TypeRegistryConverter[
-        constraints.QueryConstraint, InMemoryQueryConstraintCheck
-    ]
+    TypeRegistryConverter[constraints.QueryConstraint, InMemoryQueryApplier]
 ):
     def register[QC: constraints.QueryConstraint](
         self,
         item_type: type[QC],
-        converter: Converter[QC, InMemoryQueryConstraintCheck],
+        converter: Converter[QC, InMemoryQueryApplier],
     ) -> Self:
         return super()._register(item_type, converter)
 
@@ -53,6 +109,9 @@ class TypeRegistryConstraintConverter(
         return self.register(
             constraints.SequenceNumberAfterConstraint,
             SequenceNumberAfterConstraintConverter(),
+        ).register(
+            constraints.OffsetPagingConstraint,
+            OffsetPagingConstraintConverter(),
         )
 
 

--- a/src/logicblocks/event/store/adapters/memory/db.py
+++ b/src/logicblocks/event/store/adapters/memory/db.py
@@ -1,12 +1,10 @@
 import copy
 from collections import defaultdict
-from collections.abc import AsyncIterator, Set
+from collections.abc import AsyncIterator
 from typing import Self, cast
 
-from logicblocks.event.sources import constraints
 from logicblocks.event.types import (
     CategoryIdentifier,
-    Converter,
     JsonValue,
     LogIdentifier,
     StoredEvent,
@@ -42,10 +40,6 @@ class InMemoryEventsDB:
         log_index: EventPositionList | None = None,
         category_index: EventIndexDict[CategoryKey] | None = None,
         stream_index: EventIndexDict[StreamKey] | None = None,
-        constraint_converter: Converter[
-            constraints.QueryConstraint,
-            constraints.QueryConstraintCheck[StoredEvent],
-        ],
     ):
         self._events: list[StoredEvent[str, JsonValue] | None] = (
             events if events is not None else []
@@ -63,7 +57,6 @@ class InMemoryEventsDB:
             if stream_index is not None
             else defaultdict(lambda: [])
         )
-        self._constraint_converter = constraint_converter
 
     def snapshot(self) -> Self:
         return self.__class__(
@@ -71,7 +64,6 @@ class InMemoryEventsDB:
             log_index=list(self._log_index),
             category_index=copy.deepcopy(self._category_index),
             stream_index=copy.deepcopy(self._stream_index),
-            constraint_converter=self._constraint_converter,
         )
 
     def transaction(self) -> "InMemoryEventsDBTransaction":
@@ -122,7 +114,6 @@ class InMemoryEventsDB:
     async def scan_events(
         self,
         target: Scannable,
-        constraints: Set[constraints.QueryConstraint] = frozenset(),
     ) -> AsyncIterator[StoredEvent[str, JsonValue]]:
         index = self._select_index(target)
 
@@ -133,11 +124,6 @@ class InMemoryEventsDB:
                     f"Invalid state: event at sequence number {sequence_number} "
                     f"is None"
                 )
-            if not all(
-                self._constraint_converter.convert(constraint)(event)
-                for constraint in constraints
-            ):
-                continue
             yield event
 
     def _select_index(self, target: Scannable) -> EventPositionList:

--- a/src/logicblocks/event/store/adapters/postgres/adapter.py
+++ b/src/logicblocks/event/store/adapters/postgres/adapter.py
@@ -199,13 +199,13 @@ def scan_query(
             .right(Constant(parameters.stream))
         )
 
-    for constraint in parameters.constraints:
-        applier = constraint_converter.convert(constraint)
-        builder = applier.apply(builder)
-
     builder = builder.order_by(
         SortBy(expression=ColumnReference(field="sequence_number"))
     ).limit(parameters.page_size)
+
+    for constraint in parameters.constraints:
+        applier = constraint_converter.convert(constraint)
+        builder = applier.apply(builder)
 
     return builder.build()
 

--- a/src/logicblocks/event/store/adapters/postgres/converters.py
+++ b/src/logicblocks/event/store/adapters/postgres/converters.py
@@ -54,6 +54,27 @@ class SequenceNumberAfterConstraintConverter(
         return SequenceNumberAfterConstraintQueryApplier(item.sequence_number)
 
 
+class OffsetPagingConstraintQueryApplier(QueryApplier):
+    def __init__(self, offset: int, limit: int):
+        self._offset = offset
+        self._limit = limit
+
+    def apply(self, target: Query) -> Query:
+        result = target.limit(self._limit)
+        if self._offset > 0:
+            result = result.offset(self._offset)
+        return result
+
+
+class OffsetPagingConstraintConverter(
+    Converter[constraints.OffsetPagingConstraint, QueryApplier]
+):
+    def convert(
+        self, item: constraints.OffsetPagingConstraint
+    ) -> QueryApplier:
+        return OffsetPagingConstraintQueryApplier(item.offset, item.item_count)
+
+
 class TypeRegistryConstraintConverter(
     TypeRegistryConverter[constraints.QueryConstraint, QueryApplier]
 ):
@@ -68,6 +89,9 @@ class TypeRegistryConstraintConverter(
         return self.register(
             constraints.SequenceNumberAfterConstraint,
             SequenceNumberAfterConstraintConverter(),
+        ).register(
+            constraints.OffsetPagingConstraint,
+            OffsetPagingConstraintConverter(),
         )
 
 

--- a/src/logicblocks/event/store/sources.py
+++ b/src/logicblocks/event/store/sources.py
@@ -1,11 +1,13 @@
+from typing import cast
+
 from logicblocks.event.sources import InMemoryEventSource, constraints
+from logicblocks.event.sources.memory import InMemoryEventSourceQueryApplier
 from logicblocks.event.types import (
     Converter,
     EventSourceIdentifier,
     StoredEvent,
 )
 
-from .adapters.memory import InMemoryQueryConstraintCheck
 from .adapters.memory.converters import TypeRegistryConstraintConverter
 
 
@@ -16,6 +18,12 @@ class InMemoryStoredEventSource[
     def _get_default_constraint_converter(
         self,
     ) -> Converter[
-        constraints.QueryConstraint, InMemoryQueryConstraintCheck[E]
+        constraints.QueryConstraint, InMemoryEventSourceQueryApplier[E]
     ]:
-        return TypeRegistryConstraintConverter().with_default_constraint_converters()
+        return cast(
+            Converter[
+                constraints.QueryConstraint,
+                InMemoryEventSourceQueryApplier[E],
+            ],
+            TypeRegistryConstraintConverter().with_default_constraint_converters(),
+        )

--- a/tests/shared/logicblocks/event/testcases/store/adapters.py
+++ b/tests/shared/logicblocks/event/testcases/store/adapters.py
@@ -3410,6 +3410,229 @@ class ScanCases(Base, ABC):
         assert scanned_events == expected_events
 
 
+class ScanPagingCases(Base, ABC):
+    async def test_log_scan_returns_first_page_of_events(self):
+        adapter = self.construct_storage_adapter()
+
+        event_category = random_event_category_name()
+        event_stream = random_event_stream_name()
+
+        stored_events = await adapter.save(
+            target=identifier.StreamIdentifier(
+                category=event_category, stream=event_stream
+            ),
+            events=[
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+            ],
+        )
+
+        scanned_events = [
+            event
+            async for event in adapter.scan(
+                target=identifier.LogIdentifier(),
+                constraints={
+                    constraints.offset_paging(page_number=1, item_count=2)
+                },
+            )
+        ]
+
+        assert scanned_events == list(stored_events[:2])
+
+    async def test_log_scan_returns_second_page_of_events(self):
+        adapter = self.construct_storage_adapter()
+
+        event_category = random_event_category_name()
+        event_stream = random_event_stream_name()
+
+        stored_events = await adapter.save(
+            target=identifier.StreamIdentifier(
+                category=event_category, stream=event_stream
+            ),
+            events=[
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+            ],
+        )
+
+        scanned_events = [
+            event
+            async for event in adapter.scan(
+                target=identifier.LogIdentifier(),
+                constraints={
+                    constraints.offset_paging(page_number=2, item_count=2)
+                },
+            )
+        ]
+
+        assert scanned_events == list(stored_events[2:4])
+
+    async def test_log_scan_returns_partial_last_page(self):
+        adapter = self.construct_storage_adapter()
+
+        event_category = random_event_category_name()
+        event_stream = random_event_stream_name()
+
+        stored_events = await adapter.save(
+            target=identifier.StreamIdentifier(
+                category=event_category, stream=event_stream
+            ),
+            events=[
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+            ],
+        )
+
+        scanned_events = [
+            event
+            async for event in adapter.scan(
+                target=identifier.LogIdentifier(),
+                constraints={
+                    constraints.offset_paging(page_number=3, item_count=2)
+                },
+            )
+        ]
+
+        assert scanned_events == list(stored_events[4:])
+
+    async def test_log_scan_returns_empty_when_page_beyond_events(self):
+        adapter = self.construct_storage_adapter()
+
+        event_category = random_event_category_name()
+        event_stream = random_event_stream_name()
+
+        await adapter.save(
+            target=identifier.StreamIdentifier(
+                category=event_category, stream=event_stream
+            ),
+            events=[
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+            ],
+        )
+
+        scanned_events = [
+            event
+            async for event in adapter.scan(
+                target=identifier.LogIdentifier(),
+                constraints={
+                    constraints.offset_paging(page_number=5, item_count=2)
+                },
+            )
+        ]
+
+        assert scanned_events == []
+
+    async def test_category_scan_returns_first_page_of_events(self):
+        adapter = self.construct_storage_adapter()
+
+        event_category = random_event_category_name()
+        event_stream = random_event_stream_name()
+
+        stored_events = await adapter.save(
+            target=identifier.StreamIdentifier(
+                category=event_category, stream=event_stream
+            ),
+            events=[
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+            ],
+        )
+
+        scanned_events = [
+            event
+            async for event in adapter.scan(
+                target=identifier.CategoryIdentifier(category=event_category),
+                constraints={
+                    constraints.offset_paging(page_number=1, item_count=2)
+                },
+            )
+        ]
+
+        assert scanned_events == list(stored_events[:2])
+
+    async def test_stream_scan_returns_first_page_of_events(self):
+        adapter = self.construct_storage_adapter()
+
+        event_category = random_event_category_name()
+        event_stream = random_event_stream_name()
+
+        stored_events = await adapter.save(
+            target=identifier.StreamIdentifier(
+                category=event_category, stream=event_stream
+            ),
+            events=[
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+            ],
+        )
+
+        scanned_events = [
+            event
+            async for event in adapter.scan(
+                target=identifier.StreamIdentifier(
+                    category=event_category, stream=event_stream
+                ),
+                constraints={
+                    constraints.offset_paging(page_number=1, item_count=2)
+                },
+            )
+        ]
+
+        assert scanned_events == list(stored_events[:2])
+
+    async def test_log_scan_combines_paging_with_sequence_number_constraint(
+        self,
+    ):
+        adapter = self.construct_storage_adapter()
+
+        event_category = random_event_category_name()
+        event_stream = random_event_stream_name()
+
+        stored_events = await adapter.save(
+            target=identifier.StreamIdentifier(
+                category=event_category, stream=event_stream
+            ),
+            events=[
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+                NewEventBuilder().build(),
+            ],
+        )
+
+        sequence_number = stored_events[1].sequence_number
+
+        scanned_events = [
+            event
+            async for event in adapter.scan(
+                target=identifier.LogIdentifier(),
+                constraints={
+                    constraints.sequence_number_after(sequence_number),
+                    constraints.offset_paging(page_number=1, item_count=2),
+                },
+            )
+        ]
+
+        assert scanned_events == list(stored_events[2:4])
+
+
 class LatestCases(Base, ABC):
     async def test_latest_returns_none_when_no_events_in_stream(self):
         adapter = self.construct_storage_adapter()
@@ -3599,6 +3822,7 @@ class EventStorageAdapterCases(
     ThreadingConcurrencyCases,
     AsyncioConcurrencyCases,
     ScanCases,
+    ScanPagingCases,
     LatestCases,
     ABC,
 ):

--- a/tests/unit/logicblocks/event/query/test_clauses.py
+++ b/tests/unit/logicblocks/event/query/test_clauses.py
@@ -1,4 +1,7 @@
+import pytest
+
 from logicblocks.event.query import OffsetPagingClause
+from logicblocks.event.sources.constraints import OffsetPagingConstraint
 
 
 class TestOffsetPagingClause:
@@ -7,3 +10,34 @@ class TestOffsetPagingClause:
 
     def test_has_zero_offset_when_no_page_number_supplied(self):
         assert OffsetPagingClause(item_count=10).offset == 0
+
+
+class TestOffsetPagingConstraint:
+    def test_stores_page_number_and_item_count(self):
+        constraint = OffsetPagingConstraint(page_number=3, item_count=20)
+
+        assert constraint.page_number == 3
+        assert constraint.item_count == 20
+
+    def test_defaults_page_number_to_1(self):
+        constraint = OffsetPagingConstraint(item_count=20)
+
+        assert constraint.page_number == 1
+
+    def test_defaults_item_count_to_10(self):
+        constraint = OffsetPagingConstraint()
+
+        assert constraint.item_count == 10
+
+    def test_calculates_offset(self):
+        constraint = OffsetPagingConstraint(page_number=4, item_count=10)
+
+        assert constraint.offset == 30
+
+    def test_raises_when_page_number_less_than_1(self):
+        with pytest.raises(ValueError, match="page_number must be >= 1"):
+            OffsetPagingConstraint(page_number=0)
+
+    def test_raises_when_item_count_less_than_1(self):
+        with pytest.raises(ValueError, match="item_count must be >= 1"):
+            OffsetPagingConstraint(item_count=0)

--- a/tests/unit/logicblocks/event/sources/test_constrained.py
+++ b/tests/unit/logicblocks/event/sources/test_constrained.py
@@ -8,15 +8,16 @@ from logicblocks.event.sources.constraints import (
 )
 from logicblocks.event.store import InMemoryStoredEventSource
 from logicblocks.event.store.adapters.memory import (
-    InMemoryQueryConstraintCheck,
+    InMemoryQueryApplier,
     InMemoryTypeRegistryConstraintConverter,
+)
+from logicblocks.event.store.adapters.memory.converters import (
+    FilteringQueryApplier,
 )
 from logicblocks.event.testing import data
 from logicblocks.event.testing.builders import StoredEventBuilder
 from logicblocks.event.types import (
     Converter,
-    JsonValue,
-    StoredEvent,
     StreamIdentifier,
 )
 
@@ -110,23 +111,13 @@ class TestConstrainedEventSource:
             def __init__(self, name: str):
                 self.name = name
 
-            def met_by(self, *, event: StoredEvent) -> bool:
-                return event.name != self.name
-
-        class NotNameConstraintQueryConstraintCheck:
-            def __init__(self, constraint: NotNameConstraint):
-                self.constraint = constraint
-
-            def __call__(self, event: StoredEvent[str, JsonValue]) -> bool:
-                return event.name != self.constraint.name
-
         class NotNameConstraintConverter(
-            Converter[NotNameConstraint, InMemoryQueryConstraintCheck]
+            Converter[NotNameConstraint, InMemoryQueryApplier]
         ):
-            def convert(
-                self, item: NotNameConstraint
-            ) -> InMemoryQueryConstraintCheck:
-                return NotNameConstraintQueryConstraintCheck(item)
+            def convert(self, item: NotNameConstraint) -> InMemoryQueryApplier:
+                return FilteringQueryApplier(
+                    check=lambda event: event.name != item.name
+                )
 
         constraint_converter = (
             InMemoryTypeRegistryConstraintConverter()

--- a/tests/unit/logicblocks/event/sources/test_memory.py
+++ b/tests/unit/logicblocks/event/sources/test_memory.py
@@ -10,7 +10,7 @@ from logicblocks.event.sources.constraints import (
 from logicblocks.event.sources.memory import InMemoryEventSourceQueryApplier
 from logicblocks.event.store import InMemoryStoredEventSource
 from logicblocks.event.store.adapters.memory.converters import (
-    FILTER_ORDER,
+    QueryApplierOrder,
     TypeRegistryConstraintConverter,
 )
 from logicblocks.event.testing.builders import StoredEventBuilder
@@ -20,7 +20,7 @@ from logicblocks.event.types import CategoryIdentifier, Converter, StoredEvent
 class _NoOpApplier(InMemoryEventSourceQueryApplier[StoredEvent]):
     @property
     def order(self) -> int:
-        return FILTER_ORDER
+        return QueryApplierOrder.FILTER
 
     async def apply(
         self, target: AsyncIterator[StoredEvent]

--- a/tests/unit/logicblocks/event/sources/test_memory.py
+++ b/tests/unit/logicblocks/event/sources/test_memory.py
@@ -160,6 +160,106 @@ class TestInMemoryEventSource:
         assert source_1 != source_2
 
 
+class TestInMemoryEventSourcePaging:
+    async def test_iterate_yields_first_page_of_events(self):
+        event_1 = StoredEventBuilder().build()
+        event_2 = StoredEventBuilder().build()
+        event_3 = StoredEventBuilder().build()
+        event_4 = StoredEventBuilder().build()
+        event_5 = StoredEventBuilder().build()
+
+        source = NoConstraintsInMemoryEventSource(
+            events=[event_1, event_2, event_3, event_4, event_5],
+            identifier=CategoryIdentifier(category="test"),
+        )
+
+        constraint = constraints.offset_paging(page_number=1, item_count=2)
+        events = [
+            event async for event in source.iterate(constraints={constraint})
+        ]
+
+        assert events == [event_1, event_2]
+
+    async def test_iterate_yields_second_page_of_events(self):
+        event_1 = StoredEventBuilder().build()
+        event_2 = StoredEventBuilder().build()
+        event_3 = StoredEventBuilder().build()
+        event_4 = StoredEventBuilder().build()
+        event_5 = StoredEventBuilder().build()
+
+        source = NoConstraintsInMemoryEventSource(
+            events=[event_1, event_2, event_3, event_4, event_5],
+            identifier=CategoryIdentifier(category="test"),
+        )
+
+        constraint = constraints.offset_paging(page_number=2, item_count=2)
+        events = [
+            event async for event in source.iterate(constraints={constraint})
+        ]
+
+        assert events == [event_3, event_4]
+
+    async def test_iterate_yields_partial_last_page(self):
+        event_1 = StoredEventBuilder().build()
+        event_2 = StoredEventBuilder().build()
+        event_3 = StoredEventBuilder().build()
+        event_4 = StoredEventBuilder().build()
+        event_5 = StoredEventBuilder().build()
+
+        source = NoConstraintsInMemoryEventSource(
+            events=[event_1, event_2, event_3, event_4, event_5],
+            identifier=CategoryIdentifier(category="test"),
+        )
+
+        constraint = constraints.offset_paging(page_number=3, item_count=2)
+        events = [
+            event async for event in source.iterate(constraints={constraint})
+        ]
+
+        assert events == [event_5]
+
+    async def test_iterate_yields_nothing_when_page_beyond_events(self):
+        event_1 = StoredEventBuilder().build()
+        event_2 = StoredEventBuilder().build()
+
+        source = NoConstraintsInMemoryEventSource(
+            events=[event_1, event_2],
+            identifier=CategoryIdentifier(category="test"),
+        )
+
+        constraint = constraints.offset_paging(page_number=5, item_count=2)
+        events = [
+            event async for event in source.iterate(constraints={constraint})
+        ]
+
+        assert events == []
+
+    async def test_iterate_combines_paging_with_filter_constraints(self):
+        event_1 = StoredEventBuilder().with_sequence_number(0).build()
+        event_2 = StoredEventBuilder().with_sequence_number(1).build()
+        event_3 = StoredEventBuilder().with_sequence_number(2).build()
+        event_4 = StoredEventBuilder().with_sequence_number(3).build()
+        event_5 = StoredEventBuilder().with_sequence_number(4).build()
+
+        source = NoConstraintsInMemoryEventSource(
+            events=[event_1, event_2, event_3, event_4, event_5],
+            identifier=CategoryIdentifier(category="test"),
+            constraint_converter=TypeRegistryConstraintConverter().with_default_constraint_converters(),
+        )
+
+        events = [
+            event
+            async for event in source.iterate(
+                constraints={
+                    constraints.sequence_number_after(1),
+                    constraints.offset_paging(page_number=1, item_count=2),
+                }
+            )
+        ]
+
+        assert events == [event_3, event_4]
+
+
 class TestInMemoryStoredEventSource:
     async def test_iterate_yields_provided_events_with_constraints(self):
         event_1 = StoredEventBuilder().with_sequence_number(0).build()

--- a/tests/unit/logicblocks/event/sources/test_memory.py
+++ b/tests/unit/logicblocks/event/sources/test_memory.py
@@ -1,24 +1,39 @@
+from collections.abc import AsyncIterator
+
 from logicblocks.event.sources import (
     InMemoryEventSource,
     constraints,
 )
 from logicblocks.event.sources.constraints import (
     QueryConstraint,
-    QueryConstraintCheck,
 )
+from logicblocks.event.sources.memory import InMemoryEventSourceQueryApplier
 from logicblocks.event.store import InMemoryStoredEventSource
 from logicblocks.event.store.adapters.memory.converters import (
+    FILTER_ORDER,
     TypeRegistryConstraintConverter,
 )
 from logicblocks.event.testing.builders import StoredEventBuilder
 from logicblocks.event.types import CategoryIdentifier, Converter, StoredEvent
 
 
-class _EmptyConstraintConverter(
-    Converter[QueryConstraint, QueryConstraintCheck[StoredEvent]]
+class _NoOpApplier(InMemoryEventSourceQueryApplier[StoredEvent]):
+    @property
+    def order(self) -> int:
+        return FILTER_ORDER
+
+    async def apply(
+        self, target: AsyncIterator[StoredEvent]
+    ) -> AsyncIterator[StoredEvent]:
+        async for event in target:
+            yield event
+
+
+class _NoOpConstraintConverter(
+    Converter[QueryConstraint, InMemoryEventSourceQueryApplier[StoredEvent]]
 ):
     def convert(self, item):
-        return lambda event: True
+        return _NoOpApplier()
 
 
 class NoConstraintsInMemoryEventSource(
@@ -26,8 +41,10 @@ class NoConstraintsInMemoryEventSource(
 ):
     def _get_default_constraint_converter(
         self,
-    ) -> Converter[QueryConstraint, QueryConstraintCheck[StoredEvent]]:
-        return _EmptyConstraintConverter()
+    ) -> Converter[
+        QueryConstraint, InMemoryEventSourceQueryApplier[StoredEvent]
+    ]:
+        return _NoOpConstraintConverter()
 
 
 class TestInMemoryEventSource:
@@ -171,6 +188,7 @@ class TestInMemoryEventSourcePaging:
         source = NoConstraintsInMemoryEventSource(
             events=[event_1, event_2, event_3, event_4, event_5],
             identifier=CategoryIdentifier(category="test"),
+            constraint_converter=TypeRegistryConstraintConverter().with_default_constraint_converters(),
         )
 
         constraint = constraints.offset_paging(page_number=1, item_count=2)
@@ -190,6 +208,7 @@ class TestInMemoryEventSourcePaging:
         source = NoConstraintsInMemoryEventSource(
             events=[event_1, event_2, event_3, event_4, event_5],
             identifier=CategoryIdentifier(category="test"),
+            constraint_converter=TypeRegistryConstraintConverter().with_default_constraint_converters(),
         )
 
         constraint = constraints.offset_paging(page_number=2, item_count=2)
@@ -209,6 +228,7 @@ class TestInMemoryEventSourcePaging:
         source = NoConstraintsInMemoryEventSource(
             events=[event_1, event_2, event_3, event_4, event_5],
             identifier=CategoryIdentifier(category="test"),
+            constraint_converter=TypeRegistryConstraintConverter().with_default_constraint_converters(),
         )
 
         constraint = constraints.offset_paging(page_number=3, item_count=2)
@@ -225,6 +245,7 @@ class TestInMemoryEventSourcePaging:
         source = NoConstraintsInMemoryEventSource(
             events=[event_1, event_2],
             identifier=CategoryIdentifier(category="test"),
+            constraint_converter=TypeRegistryConstraintConverter().with_default_constraint_converters(),
         )
 
         constraint = constraints.offset_paging(page_number=5, item_count=2)

--- a/tests/unit/logicblocks/event/store/adapters/memory/test_converters.py
+++ b/tests/unit/logicblocks/event/store/adapters/memory/test_converters.py
@@ -1,10 +1,16 @@
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 
 import pytest
 
+from logicblocks.event.sources import constraints
 from logicblocks.event.store.adapters.memory.converters import (
     AndConditionConverter,
+    FilteringQueryApplier,
+    OffsetPagingConstraintConverter,
+    OffsetPagingQueryApplier,
     OrConditionConverter,
+    SequenceNumberAfterConstraintConverter,
     TypeRegistryConditionConverter,
     TypeRegistryConstraintConverter,
     WriteConditionEnforcer,
@@ -119,11 +125,7 @@ def make_test_type_registry_converter() -> TypeRegistryConditionConverter:
 
 
 def make_transaction() -> InMemoryEventsDBTransaction:
-    return InMemoryEventsDBTransaction(
-        db=InMemoryEventsDB(
-            constraint_converter=TypeRegistryConstraintConverter().with_default_constraint_converters()
-        )
-    )
+    return InMemoryEventsDBTransaction(db=InMemoryEventsDB())
 
 
 def make_context(
@@ -354,3 +356,181 @@ class TestWriteConditionsOr:
             enforcer.assert_satisfied(
                 context=make_context(event), transaction=make_transaction()
             )
+
+
+async def _collect[E](iterator: AsyncIterator[E]) -> list[E]:
+    return [item async for item in iterator]
+
+
+async def _async_iter[E](*items: E) -> AsyncIterator[E]:
+    for item in items:
+        yield item
+
+
+class TestFilteringQueryApplier:
+    async def test_yields_events_matching_predicate(self):
+        event_1 = StoredEventBuilder().with_sequence_number(0).build()
+        event_2 = StoredEventBuilder().with_sequence_number(1).build()
+        event_3 = StoredEventBuilder().with_sequence_number(2).build()
+
+        applier = FilteringQueryApplier(check=lambda e: e.sequence_number > 0)
+        result = await _collect(
+            applier.apply(_async_iter(event_1, event_2, event_3))
+        )
+
+        assert result == [event_2, event_3]
+
+    async def test_yields_nothing_when_no_events_match(self):
+        event_1 = StoredEventBuilder().with_sequence_number(0).build()
+
+        applier = FilteringQueryApplier(check=lambda e: e.sequence_number > 5)
+        result = await _collect(applier.apply(_async_iter(event_1)))
+
+        assert result == []
+
+    async def test_yields_all_events_when_all_match(self):
+        event_1 = StoredEventBuilder().build()
+        event_2 = StoredEventBuilder().build()
+
+        applier = FilteringQueryApplier(check=lambda e: True)
+        result = await _collect(applier.apply(_async_iter(event_1, event_2)))
+
+        assert result == [event_1, event_2]
+
+    async def test_has_filter_order(self):
+        applier = FilteringQueryApplier(check=lambda e: True)
+
+        assert applier.order == 0
+
+
+class TestOffsetPagingQueryApplier:
+    async def test_yields_first_page(self):
+        event_1 = StoredEventBuilder().build()
+        event_2 = StoredEventBuilder().build()
+        event_3 = StoredEventBuilder().build()
+
+        applier = OffsetPagingQueryApplier(offset=0, limit=2)
+        result = await _collect(
+            applier.apply(_async_iter(event_1, event_2, event_3))
+        )
+
+        assert result == [event_1, event_2]
+
+    async def test_yields_second_page(self):
+        event_1 = StoredEventBuilder().build()
+        event_2 = StoredEventBuilder().build()
+        event_3 = StoredEventBuilder().build()
+        event_4 = StoredEventBuilder().build()
+
+        applier = OffsetPagingQueryApplier(offset=2, limit=2)
+        result = await _collect(
+            applier.apply(_async_iter(event_1, event_2, event_3, event_4))
+        )
+
+        assert result == [event_3, event_4]
+
+    async def test_yields_partial_last_page(self):
+        event_1 = StoredEventBuilder().build()
+        event_2 = StoredEventBuilder().build()
+        event_3 = StoredEventBuilder().build()
+
+        applier = OffsetPagingQueryApplier(offset=2, limit=2)
+        result = await _collect(
+            applier.apply(_async_iter(event_1, event_2, event_3))
+        )
+
+        assert result == [event_3]
+
+    async def test_yields_nothing_when_offset_beyond_events(self):
+        event_1 = StoredEventBuilder().build()
+
+        applier = OffsetPagingQueryApplier(offset=10, limit=2)
+        result = await _collect(applier.apply(_async_iter(event_1)))
+
+        assert result == []
+
+    async def test_has_window_order(self):
+        applier = OffsetPagingQueryApplier(offset=0, limit=10)
+
+        assert applier.order == 1
+
+
+class TestSequenceNumberAfterConstraintConverter:
+    async def test_produces_filtering_applier(self):
+        converter = SequenceNumberAfterConstraintConverter()
+        constraint = constraints.SequenceNumberAfterConstraint(
+            sequence_number=1
+        )
+
+        applier = converter.convert(constraint)
+
+        assert isinstance(applier, FilteringQueryApplier)
+
+    async def test_applier_filters_by_sequence_number(self):
+        converter = SequenceNumberAfterConstraintConverter()
+        constraint = constraints.SequenceNumberAfterConstraint(
+            sequence_number=1
+        )
+
+        event_1 = StoredEventBuilder().with_sequence_number(0).build()
+        event_2 = StoredEventBuilder().with_sequence_number(1).build()
+        event_3 = StoredEventBuilder().with_sequence_number(2).build()
+
+        applier = converter.convert(constraint)
+        result = await _collect(
+            applier.apply(_async_iter(event_1, event_2, event_3))
+        )
+
+        assert result == [event_3]
+
+
+class TestOffsetPagingConstraintConverter:
+    async def test_produces_paging_applier(self):
+        converter = OffsetPagingConstraintConverter()
+        constraint = constraints.OffsetPagingConstraint(
+            page_number=2, item_count=3
+        )
+
+        applier = converter.convert(constraint)
+
+        assert isinstance(applier, OffsetPagingQueryApplier)
+
+    async def test_applier_pages_events(self):
+        converter = OffsetPagingConstraintConverter()
+        constraint = constraints.OffsetPagingConstraint(
+            page_number=2, item_count=2
+        )
+
+        event_1 = StoredEventBuilder().build()
+        event_2 = StoredEventBuilder().build()
+        event_3 = StoredEventBuilder().build()
+        event_4 = StoredEventBuilder().build()
+
+        applier = converter.convert(constraint)
+        result = await _collect(
+            applier.apply(_async_iter(event_1, event_2, event_3, event_4))
+        )
+
+        assert result == [event_3, event_4]
+
+
+class TestTypeRegistryConstraintConverterWithAppliers:
+    async def test_converts_sequence_number_constraint(self):
+        converter = TypeRegistryConstraintConverter().with_default_constraint_converters()
+        constraint = constraints.SequenceNumberAfterConstraint(
+            sequence_number=1
+        )
+
+        applier = converter.convert(constraint)
+
+        assert isinstance(applier, FilteringQueryApplier)
+
+    async def test_converts_paging_constraint(self):
+        converter = TypeRegistryConstraintConverter().with_default_constraint_converters()
+        constraint = constraints.OffsetPagingConstraint(
+            page_number=1, item_count=10
+        )
+
+        applier = converter.convert(constraint)
+
+        assert isinstance(applier, OffsetPagingQueryApplier)

--- a/uv.lock
+++ b/uv.lock
@@ -302,7 +302,7 @@ wheels = [
 
 [[package]]
 name = "logicblocks-event-store"
-version = "0.1.10a18"
+version = "0.1.10a19"
 source = { editable = "." }
 dependencies = [
     { name = "aiologic" },


### PR DESCRIPTION
- Add `OffsetPagingConstraint` — a new query constraint that models pagination (page number + item count) as part of the existing constraint system. Preserves lazy iteration in all adapters.
- Postgres adapter — `OffsetPagingConstraintConverter` converts the constraint into a `QueryApplier` that applies LIMIT/OFFSET to the SQL query, fitting naturally into the existing converter registry.
- In-memory adapter — introduces `InMemoryQueryApplier` hierarchy (mirroring postgres's `QueryApplier`) with `FilteringQueryApplier` and `OffsetPagingQueryApplier`. Both filter and paging constraints now flow through the converter registry with ordering (`QueryApplierOrder.FILTER` before `QueryApplierOrder.WINDOW`). Constraint handling removed from `InMemoryEventsDB`.