### PR TITLE
Add native Pydantic BaseModel support for event payloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "structlog>=25.1.0",
     "rich>=14.0.0",
     "aiologic>=0.15.0",
+    "pydantic>=2.0.0",
 ]
 
 [dependency-groups]

--- a/src/logicblocks/event/types/conversion.py
+++ b/src/logicblocks/event/types/conversion.py
@@ -3,6 +3,8 @@ from inspect import isclass
 from types import NoneType
 from typing import Any, cast, get_args, get_origin
 
+from pydantic import BaseModel as PydanticBaseModel
+
 from .json import (
     JsonValue,
     JsonValueConvertible,
@@ -18,8 +20,8 @@ from .string import (
     StringSerialisable,
 )
 
-type JsonPersistable = JsonValueConvertible | JsonValue
-type JsonLoggable = JsonValueSerialisable | JsonValue
+type JsonPersistable = JsonValueConvertible | JsonValue | PydanticBaseModel
+type JsonLoggable = JsonValueSerialisable | JsonValue | PydanticBaseModel
 
 type StringPersistable = StringConvertible | str
 type StringLoggable = StringSerialisable | str
@@ -47,6 +49,8 @@ def serialise_to_json_value(
 ) -> JsonValue:
     if isinstance(value, JsonValueSerialisable):
         return value.serialise(fallback)
+    if isinstance(value, PydanticBaseModel):
+        return value.model_dump(mode="json", by_alias=True)
     if is_json_value(value):
         return value
     return fallback(value)
@@ -160,6 +164,13 @@ def deserialise_from_json_value[T](
         and issubclass(klass, JsonValueDeserialisable)
     ):
         return klass.deserialise(value, fallback)
+
+    if (
+        value_is_json_object
+        and klass_is_class
+        and issubclass(klass, PydanticBaseModel)
+    ):
+        return klass.model_validate(value)
 
     return fallback(klass_original, value)
 

--- a/tests/unit/logicblocks/event/types/test_conversion.py
+++ b/tests/unit/logicblocks/event/types/test_conversion.py
@@ -1,10 +1,11 @@
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from types import NoneType
 from typing import Any, Self
 
 import pytest
+from pydantic import BaseModel, ConfigDict, Field
 
 from logicblocks.event.types import (
     JsonValue,
@@ -1011,3 +1012,189 @@ class TestDeserialise:
         assert deserialise_from_json_value(Thing, value, fallback) == Thing(
             value=10
         )
+
+
+class SimplePydanticModel(BaseModel):
+    name: str
+    count: int
+
+
+class PydanticModelWithAlias(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    from_: str = Field(alias="from")
+    subject: str
+
+
+class PydanticModelWithDatetime(BaseModel):
+    name: str
+    created_at: datetime
+
+
+class NestedPydanticModel(BaseModel):
+    inner: SimplePydanticModel
+    label: str
+
+
+class PydanticModelWithDefaults(BaseModel):
+    name: str
+    optional_field: str | None = None
+    count: int = 0
+
+
+class TestSerialisePydantic:
+    def test_serialises_simple_pydantic_model(self):
+        model = SimplePydanticModel(name="test", count=5)
+        result = serialise_to_json_value(model)
+        assert result == {"name": "test", "count": 5}
+
+    def test_serialises_pydantic_model_with_alias_using_alias(self):
+        model = PydanticModelWithAlias(
+            **{"from": "sender", "subject": "hello"}
+        )
+        result = serialise_to_json_value(model)
+        assert result == {"from": "sender", "subject": "hello"}
+
+    def test_serialises_pydantic_model_with_datetime_to_iso_string(self):
+        dt = datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
+        model = PydanticModelWithDatetime(name="test", created_at=dt)
+        result = serialise_to_json_value(model)
+        assert result == {
+            "name": "test",
+            "created_at": "2024-01-15T10:30:00Z",
+        }
+
+    def test_serialises_nested_pydantic_model(self):
+        model = NestedPydanticModel(
+            inner=SimplePydanticModel(name="inner", count=1),
+            label="outer",
+        )
+        result = serialise_to_json_value(model)
+        assert result == {
+            "inner": {"name": "inner", "count": 1},
+            "label": "outer",
+        }
+
+    def test_serialises_pydantic_model_with_defaults(self):
+        model = PydanticModelWithDefaults(name="test")
+        result = serialise_to_json_value(model)
+        assert result == {
+            "name": "test",
+            "optional_field": None,
+            "count": 0,
+        }
+
+    def test_serialises_pydantic_model_with_none_field(self):
+        model = PydanticModelWithDefaults(name="test", optional_field=None)
+        result = serialise_to_json_value(model)
+        assert result == {
+            "name": "test",
+            "optional_field": None,
+            "count": 0,
+        }
+
+    def test_json_value_serialisable_takes_priority_over_pydantic(self):
+        class DualModel(BaseModel):
+            name: str
+
+            def serialise(
+                self,
+                fallback: Callable[[object], JsonValue],
+            ) -> JsonValue:
+                return {"custom": True, "name": self.name}
+
+        model = DualModel(name="test")
+        result = serialise_to_json_value(model)
+        assert result == {"custom": True, "name": "test"}
+
+
+class TestDeserialisePydantic:
+    def test_deserialises_dict_to_simple_pydantic_model(self):
+        value = {"name": "test", "count": 5}
+        result = deserialise_from_json_value(SimplePydanticModel, value)
+        assert result == SimplePydanticModel(name="test", count=5)
+
+    def test_deserialises_dict_with_alias_to_pydantic_model(self):
+        value = {"from": "sender", "subject": "hello"}
+        result = deserialise_from_json_value(PydanticModelWithAlias, value)
+        assert result.from_ == "sender"
+        assert result.subject == "hello"
+
+    def test_deserialises_dict_with_field_name_to_pydantic_model(
+        self,
+    ):
+        value = {"from_": "sender", "subject": "hello"}
+        result = deserialise_from_json_value(PydanticModelWithAlias, value)
+        assert result.from_ == "sender"
+        assert result.subject == "hello"
+
+    def test_deserialises_dict_with_datetime_string_to_pydantic_model(
+        self,
+    ):
+        value = {
+            "name": "test",
+            "created_at": "2024-01-15T10:30:00Z",
+        }
+        result = deserialise_from_json_value(PydanticModelWithDatetime, value)
+        assert result.name == "test"
+        assert result.created_at == datetime(
+            2024, 1, 15, 10, 30, 0, tzinfo=UTC
+        )
+
+    def test_deserialises_nested_dict_to_nested_pydantic_model(self):
+        value = {
+            "inner": {"name": "inner", "count": 1},
+            "label": "outer",
+        }
+        result = deserialise_from_json_value(NestedPydanticModel, value)
+        assert result == NestedPydanticModel(
+            inner=SimplePydanticModel(name="inner", count=1),
+            label="outer",
+        )
+
+    def test_deserialises_dict_with_defaults_to_pydantic_model(self):
+        value = {"name": "test"}
+        result = deserialise_from_json_value(PydanticModelWithDefaults, value)
+        assert result == PydanticModelWithDefaults(
+            name="test", optional_field=None, count=0
+        )
+
+    def test_deserialises_dict_with_extra_fields_ignored(self):
+        value = {"name": "test", "count": 5, "extra": "ignored"}
+        result = deserialise_from_json_value(SimplePydanticModel, value)
+        assert result == SimplePydanticModel(name="test", count=5)
+
+    def test_deserialises_pydantic_model_instance_unchanged(self):
+        model = SimplePydanticModel(name="test", count=5)
+        result = deserialise_from_json_value(
+            SimplePydanticModel, {"name": "test", "count": 5}
+        )
+        assert result == model
+
+    def test_raises_for_invalid_pydantic_data(self):
+        value = {"name": "test"}
+        with pytest.raises(Exception):
+            deserialise_from_json_value(SimplePydanticModel, value)
+
+    def test_raises_for_non_dict_value_with_pydantic_type(self):
+        with pytest.raises(Exception):
+            deserialise_from_json_value(SimplePydanticModel, "string")
+
+    def test_json_value_deserialisable_takes_priority_over_pydantic(
+        self,
+    ):
+        class DualModel(BaseModel):
+            name: str
+
+            @classmethod
+            def deserialise(
+                cls,
+                value: JsonValue,
+                fallback: Callable[[Any, JsonValue], Any],
+            ) -> "DualModel":
+                if not is_json_object(value) or "name" not in value:
+                    raise ValueError
+                return cls(name=f"custom_{value['name']}")
+
+        value = {"name": "test"}
+        result = deserialise_from_json_value(DualModel, value)
+        assert result.name == "custom_test"

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -302,11 +311,12 @@ wheels = [
 
 [[package]]
 name = "logicblocks-event-store"
-version = "0.1.10a18"
+version = "0.1.10a19"
 source = { editable = "." }
 dependencies = [
     { name = "aiologic" },
     { name = "psycopg", extra = ["binary", "pool"] },
+    { name = "pydantic" },
     { name = "pyheck" },
     { name = "rich" },
     { name = "structlog" },
@@ -343,6 +353,7 @@ docs = [
 requires-dist = [
     { name = "aiologic", specifier = ">=0.15.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.3" },
+    { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pyheck", specifier = ">=0.1.5" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "structlog", specifier = ">=25.1.0" },
@@ -720,6 +731,77 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/6b/69fd5c7194b21ebde0f8637e2a4ddc766ada29d472bfa6a5ca533d79549a/pydantic-2.13.0.tar.gz", hash = "sha256:b89b575b6e670ebf6e7448c01b41b244f471edd276cd0b6fe02e7e7aca320070", size = 843468, upload-time = "2026-04-13T10:51:35.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/d7/c3a52c61f5b7be648e919005820fbac33028c6149994cd64453f49951c17/pydantic-2.13.0-py3-none-any.whl", hash = "sha256:ab0078b90da5f3e2fd2e71e3d9b457ddcb35d0350854fbda93b451e28d56baaf", size = 471872, upload-time = "2026-04-13T10:51:33.343Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/0a/9414cddf82eda3976b14048cc0fa8f5b5d1aecb0b22e1dcd2dbfe0e139b1/pydantic_core-2.46.0.tar.gz", hash = "sha256:82d2498c96be47b47e903e1378d1d0f770097ec56ea953322f39936a7cf34977", size = 471441, upload-time = "2026-04-13T09:06:33.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/05/ab3b0742bad1d51822f1af0c4232208408902bdcfc47601f3b812e09e6c2/pydantic_core-2.46.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:a05900c37264c070c683c650cbca8f83d7cbb549719e645fcd81a24592eac788", size = 2116814, upload-time = "2026-04-13T09:04:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/98/08/30b43d9569d69094a0899a199711c43aa58fce6ce80f6a8f7693673eb995/pydantic_core-2.46.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de8e482fd4f1e3f36c50c6aac46d044462615d8f12cfafc6bebeaa0909eea22", size = 1951867, upload-time = "2026-04-13T09:04:02.364Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a0/bf9a1ba34537c2ed3872a48195291138fdec8fe26c4009776f00d63cf0c8/pydantic_core-2.46.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c525ecf8a4cdf198327b65030a7d081867ad8e60acb01a7214fff95cf9832d47", size = 1977040, upload-time = "2026-04-13T09:06:16.088Z" },
+    { url = "https://files.pythonhosted.org/packages/71/70/0ba03c20e1e118219fc18c5417b008b7e880f0e3fb38560ec4465984d471/pydantic_core-2.46.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f14581aeb12e61542ce73b9bfef2bca5439d65d9ab3efe1a4d8e346b61838f9b", size = 2055284, upload-time = "2026-04-13T09:05:25.125Z" },
+    { url = "https://files.pythonhosted.org/packages/58/cf/1e320acefbde7fb7158a9e5def55e0adf9a4634636098ce28dc6b978e0d3/pydantic_core-2.46.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c108067f2f7e190d0dbd81247d789ec41f9ea50ccd9265a3a46710796ac60530", size = 2238896, upload-time = "2026-04-13T09:05:01.345Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f5/ea8ba209756abe9eba891bb0ef3772b4c59a894eb9ad86cd5bd0dd4e3e52/pydantic_core-2.46.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1ac10967e9a7bb1b96697374513f9a1a90a59e2fb41566b5e00ee45392beac59", size = 2314353, upload-time = "2026-04-13T09:06:07.942Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f8/5885350203b72e96438eee7f94de0d8f0442f4627237ca8ef75de34db1cd/pydantic_core-2.46.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7897078fe8a13b73623c0955dfb2b3d2c9acb7177aac25144758c9e5a5265aaa", size = 2098522, upload-time = "2026-04-13T09:04:23.239Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/88/5930b0e828e371db5a556dd3189565417ddc3d8316bb001058168aadcf5f/pydantic_core-2.46.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:e69ce405510a419a082a78faed65bb4249cfb51232293cc675645c12f7379bf7", size = 2168757, upload-time = "2026-04-13T09:07:12.46Z" },
+    { url = "https://files.pythonhosted.org/packages/da/75/63d563d3035a0548e721c38b5b69fd5626fdd51da0f09ff4467503915b82/pydantic_core-2.46.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fd28d13eea0d8cf351dc1fe274b5070cc8e1cca2644381dee5f99de629e77cf3", size = 2202518, upload-time = "2026-04-13T09:05:44.418Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/53/1958eacbfddc41aadf5ae86dd85041bf054b675f34a2fa76385935f96070/pydantic_core-2.46.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:ee1547a6b8243e73dd10f585555e5a263395e55ce6dea618a078570a1e889aef", size = 2190148, upload-time = "2026-04-13T09:06:56.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/17/098cc6d3595e4623186f2bc6604a6195eb182e126702a90517236391e9ce/pydantic_core-2.46.0-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:c3dc68dcf62db22a18ddfc3ad4960038f72b75908edc48ae014d7ac8b391d57a", size = 2342925, upload-time = "2026-04-13T09:04:17.286Z" },
+    { url = "https://files.pythonhosted.org/packages/71/a7/abdb924620b1ac535c690b36ad5b8871f376104090f8842c08625cecf1d3/pydantic_core-2.46.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:004a2081c881abfcc6854a4623da6a09090a0d7c1398a6ae7133ca1256cee70b", size = 2383167, upload-time = "2026-04-13T09:04:52.643Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c9/2ddd10f50e4b7350d2574629a0f53d8d4eb6573f9c19a6b43e6b1487a31d/pydantic_core-2.46.0-cp313-cp313-win32.whl", hash = "sha256:59d24ec8d5eaabad93097525a69d0f00f2667cb353eb6cda578b1cfff203ceef", size = 1965660, upload-time = "2026-04-13T09:06:05.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e7/1efc38ed6f2680c032bcefa0e3ebd496a8c77e92dfdb86b07d0f2fc632b1/pydantic_core-2.46.0-cp313-cp313-win_amd64.whl", hash = "sha256:71186dad5ac325c64d68fe0e654e15fd79802e7cc42bc6f0ff822d5ad8b1ab25", size = 2069563, upload-time = "2026-04-13T09:07:14.738Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1e/a325b4989e742bf7e72ed35fa124bc611fd76539c9f8cd2a9a7854473533/pydantic_core-2.46.0-cp313-cp313-win_arm64.whl", hash = "sha256:8e4503f3213f723842c9a3b53955c88a9cfbd0b288cbd1c1ae933aebeec4a1b4", size = 2034966, upload-time = "2026-04-13T09:04:21.629Z" },
+    { url = "https://files.pythonhosted.org/packages/36/3b/914891d384cdbf9a6f464eb13713baa22ea1e453d4da80fb7da522079370/pydantic_core-2.46.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:4fc801c290342350ffc82d77872054a934b2e24163727263362170c1db5416ca", size = 2113349, upload-time = "2026-04-13T09:04:59.407Z" },
+    { url = "https://files.pythonhosted.org/packages/35/95/3a0c6f65e231709fb3463e32943c69d10285cb50203a2130a4732053a06d/pydantic_core-2.46.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0a36f2cc88170cc177930afcc633a8c15907ea68b59ac16bd180c2999d714940", size = 1949170, upload-time = "2026-04-13T09:06:09.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/d845c36a608469fe7bee226edeff0984c33dbfe7aecd755b0e7ab5a275c4/pydantic_core-2.46.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2a3912e0c568a1f99d4d6d3e41def40179d61424c0ca1c8c87c4877d7f6fd7fb", size = 1977914, upload-time = "2026-04-13T09:04:56.16Z" },
+    { url = "https://files.pythonhosted.org/packages/08/6f/f2e7a7f85931fb31671f5378d1c7fc70606e4b36d59b1b48e1bd1ef5d916/pydantic_core-2.46.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3534c3415ed1a19ab23096b628916a827f7858ec8db49ad5d7d1e44dc13c0d7b", size = 2050538, upload-time = "2026-04-13T09:05:06.789Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/f4aa7181dd9a16dd9059a99fc48fdab0c2aab68307283a5c04cf56de68c4/pydantic_core-2.46.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:21067396fc285609323a4db2f63a87570044abe0acddfcca8b135fc7948e3db7", size = 2236294, upload-time = "2026-04-13T09:07:03.2Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c1/6a5042fc32765c87101b500f394702890af04239c318b6002cfd627b710d/pydantic_core-2.46.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2afd85b7be186e2fe7cdbb09a3d964bcc2042f65bbcc64ad800b3c7915032655", size = 2312954, upload-time = "2026-04-13T09:06:11.919Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e4/566101a561492ce8454f0844ca29c3b675a6b3a7b3ff577db85ed05c8c50/pydantic_core-2.46.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67e2c2e171b78db8154da602de72ffdc473c6ee51de8a9d80c0f1cd4051abfc7", size = 2102533, upload-time = "2026-04-13T09:06:58.664Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ac/adc11ee1646a5c4dd9abb09a00e7909e6dc25beddc0b1310ca734bb9b48e/pydantic_core-2.46.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c16ae1f3170267b1a37e16dba5c297bdf60c8b5657b147909ca8774ce7366644", size = 2169447, upload-time = "2026-04-13T09:04:11.143Z" },
+    { url = "https://files.pythonhosted.org/packages/26/73/408e686b45b82d28ac19e8229e07282254dbee6a5d24c5c7cf3cf3716613/pydantic_core-2.46.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:133b69e1c1ba34d3702eed73f19f7f966928f9aa16663b55c2ebce0893cca42e", size = 2200672, upload-time = "2026-04-13T09:03:54.056Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/3b/807d5b035ec891b57b9079ce881f48263936c37bd0d154a056e7fd152afb/pydantic_core-2.46.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:15ed8e5bde505133d96b41702f31f06829c46b05488211a5b1c7877e11de5eb5", size = 2188293, upload-time = "2026-04-13T09:07:07.614Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ed/719b307516285099d1196c52769fdbe676fd677da007b9c349ae70b7226d/pydantic_core-2.46.0-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:8cfc29a1c66a7f0fcb36262e92f353dd0b9c4061d558fceb022e698a801cb8ae", size = 2335023, upload-time = "2026-04-13T09:04:05.176Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/90/8718e4ae98c4e8a7325afdc079be82be1e131d7a47cb6c098844a9531ffe/pydantic_core-2.46.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e1155708540f13845bf68d5ac511a55c76cfe2e057ed12b4bf3adac1581fc5c2", size = 2377155, upload-time = "2026-04-13T09:06:18.081Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/dc/7172789283b963f81da2fc92b186e22de55687019079f71c4d570822502b/pydantic_core-2.46.0-cp314-cp314-win32.whl", hash = "sha256:de5635a48df6b2eef161d10ea1bc2626153197333662ba4cd700ee7ec1aba7f5", size = 1963078, upload-time = "2026-04-13T09:05:30.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/69/03a7ea4b6264def3a44eabf577528bcec2f49468c5698b2044dea54dc07e/pydantic_core-2.46.0-cp314-cp314-win_amd64.whl", hash = "sha256:f07a5af60c5e7cf53dd1ff734228bd72d0dc9938e64a75b5bb308ca350d9681e", size = 2068439, upload-time = "2026-04-13T09:04:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/eb/1c3afcfdee2ab6634b802ab0a0f1966df4c8b630028ec56a1cb0a710dc58/pydantic_core-2.46.0-cp314-cp314-win_arm64.whl", hash = "sha256:e7a77eca3c7d5108ff509db20aae6f80d47c7ed7516d8b96c387aacc42f3ce0f", size = 2026470, upload-time = "2026-04-13T09:05:08.654Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/30/1177dde61b200785c4739665e3aa03a9d4b2c25d2d0408b07d585e633965/pydantic_core-2.46.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5e7cdd4398bee1aaeafe049ac366b0f887451d9ae418fd8785219c13fea2f928", size = 2107447, upload-time = "2026-04-13T09:05:46.314Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/60/4e0f61f99bdabbbc309d364a2791e1ba31e778a4935bc43391a7bdec0744/pydantic_core-2.46.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5c2c92d82808e27cef3f7ab3ed63d657d0c755e0dbe5b8a58342e37bdf09bd2e", size = 1926927, upload-time = "2026-04-13T09:06:20.371Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/d0/67f89a8269152c1d6eaa81f04e75a507372ebd8ca7382855a065222caa80/pydantic_core-2.46.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bab80af91cd7014b45d1089303b5f844a9d91d7da60eabf3d5f9694b32a6655", size = 1966613, upload-time = "2026-04-13T09:07:05.389Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/07/8dfdc3edc78f29a80fb31f366c50203ec904cff6a4c923599bf50ac0d0ff/pydantic_core-2.46.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1e49ffdb714bc990f00b39d1ad1d683033875b5af15582f60c1f34ad3eeccfaa", size = 2032902, upload-time = "2026-04-13T09:06:42.47Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2a/111c5e8fe24f99c46bcad7d3a82a8f6dbc738066e2c72c04c71f827d8c78/pydantic_core-2.46.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ca877240e8dbdeef3a66f751dc41e5a74893767d510c22a22fc5c0199844f0ce", size = 2244456, upload-time = "2026-04-13T09:05:36.484Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/7c/cfc5d11c15a63ece26e148572c77cfbb2c7f08d315a7b63ef0fe0711d753/pydantic_core-2.46.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87e6843f89ecd2f596d7294e33196c61343186255b9880c4f1b725fde8b0e20d", size = 2294535, upload-time = "2026-04-13T09:06:01.689Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2c/f0d744e3dab7bd026a3f4670a97a295157cff923a2666d30a15a70a7e3d0/pydantic_core-2.46.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e20bc5add1dd9bc3b9a3600d40632e679376569098345500799a6ad7c5d46c72", size = 2104621, upload-time = "2026-04-13T09:04:34.388Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/64/e7cc4698dc024264d214b51d5a47a2404221b12060dd537d76f831b2120a/pydantic_core-2.46.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:ee6ff79a5f0289d64a9d6696a3ce1f98f925b803dd538335a118231e26d6d827", size = 2130718, upload-time = "2026-04-13T09:04:26.23Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a8/224e655fec21f7d4441438ad2ecaccb33b5a3876ce7bb2098c74a49efc14/pydantic_core-2.46.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:52d35cfb58c26323101c7065508d7bb69bb56338cda9ea47a7b32be581af055d", size = 2180738, upload-time = "2026-04-13T09:05:50.253Z" },
+    { url = "https://files.pythonhosted.org/packages/32/7b/b3025618ed4c4e4cbaa9882731c19625db6669896b621760ea95bc1125ef/pydantic_core-2.46.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d14cc5a6f260fa78e124061eebc5769af6534fc837e9a62a47f09a2c341fa4ea", size = 2171222, upload-time = "2026-04-13T09:07:29.929Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e3/68170aa1d891920af09c1f2f34df61dc5ff3a746400027155523e3400e89/pydantic_core-2.46.0-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:4f7ff859d663b6635f6307a10803d07f0d09487e16c3d36b1744af51dbf948b2", size = 2320040, upload-time = "2026-04-13T09:06:35.732Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1b/5e65807001b84972476300c1f49aea2b4971b7e9fffb5c2654877dadd274/pydantic_core-2.46.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:8ef749be6ed0d69dba31902aaa8255a9bb269ae50c93888c4df242d8bb7acd9e", size = 2377062, upload-time = "2026-04-13T09:07:39.945Z" },
+    { url = "https://files.pythonhosted.org/packages/75/03/48caa9dd5f28f7662bd52bff454d9a451f6b7e5e4af95e289e5e170749c9/pydantic_core-2.46.0-cp314-cp314t-win32.whl", hash = "sha256:d93ca72870133f86360e4bb0c78cd4e6ba2a0f9f3738a6486909ffc031463b32", size = 1951028, upload-time = "2026-04-13T09:04:20.224Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ed/e97ff55fe28c0e6e3cba641d622b15e071370b70e5f07c496b07b65db7c9/pydantic_core-2.46.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6ebb2668afd657e2127cb40f2ceb627dd78e74e9dfde14d9bf6cdd532a29ff59", size = 2048519, upload-time = "2026-04-13T09:05:10.464Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/51/e0db8267a287994546925f252e329eeae4121b1e77e76353418da5a3adf0/pydantic_core-2.46.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4864f5bbb7993845baf9209bae1669a8a76769296a018cb569ebda9dcb4241f5", size = 2026791, upload-time = "2026-04-13T09:04:37.724Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1048,6 +1130,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
There's a lot of boilerplate around writing event payloads, manually constructing dicts for `NewEvent`, then pulling them apart with `.get()` calls and type checks in projections. Thought it'd be good if the library supported Pydantic models natively for the event payloads, giving us better type safety too.

This PR adds that support in the conversion layer. Existing `JsonValueSerialisable`/`JsonValueDeserialisable` protocol implementations still take priority.

`pydantic>=2.0.0` is added as a core dependency, but could be add an optional depencency.

### What it looked like before

Creating events meant manually building dicts and serialising nested objects:

```python
NewEvent[str, JsonValue](
    name=SEND_EMAIL_REQUESTED,
    payload={
        "to": [r.model_dump() for r in request.to],
        "cc": [r.model_dump() for r in request.cc],
        "from": {
            "address": from_address,
            "name": from_name,
        },
        "subject": request.subject,
        "content": request.content.model_dump(),
        "created_by": created_by,
    },
    occurred_at=time,
    observed_at=time,
)
```

And projections had a lot of `.get()` calls, type checks, and manual parsing:

```python
payload = cast(JsonObject, event.payload)

to_data = payload.get("to", [])
if not isinstance(to_data, list):
    raise InvalidEventPayloadError("'to' must be a list")

from_data = payload.get("from", {})
if not isinstance(from_data, dict):
    raise InvalidEventPayloadError("'from' must be an object")

subject = payload.get("subject", "")
occurred_at_str = payload.get("occurred_at")
occurred_at = datetime.fromisoformat(occurred_at_str)  # manual datetime parsing
```

### What it looks like now

Define a Pydantic model and pass it directly:

```python
class SendEmailRequestedPayload(BaseModel):
    model_config = ConfigDict(populate_by_name=True)

    to: list[Recipient]
    cc: list[Recipient] = Field(default_factory=list)
    from_: FromAddress = Field(alias="from")
    subject: str | None = None
    content: RequestContent
    created_by: str = ""

NewEvent(
    name=SEND_EMAIL_REQUESTED,
    payload=SendEmailRequestedPayload(
        to=list(request.to),
        from_=FromAddress(address=from_address, name=from_name),
        subject=request.subject,
        content=request.content,
        created_by=created_by,
    ),
    occurred_at=time,
    observed_at=time,
)
```

And projections just validate and use attribute access:

```python
payload = SendEmailRequestedPayload.model_validate(event.payload)

recipient_statuses = build_recipient_statuses(
    payload.to, payload.cc, payload.bcc
)
subject = payload.subject
occurred_at = payload.occurred_at  # already a datetime
```

### Changes

- Add `pydantic>=2.0.0` as a core dependency
- Update `JsonPersistable` and `JsonLoggable` type aliases to include `PydanticBaseModel`
- Add Pydantic serialisation in `serialise_to_json_value()` (after `JsonValueSerialisable` check)
- Add Pydantic deserialisation in `deserialise_from_json_value()` (before final fallback)
- Add 18 unit tests covering serialisation, deserialisation, aliases, datetimes, nesting, defaults, and priority behaviour