### PR TITLE
Export `make_event_store_subscriber` from processing package

### DIFF
--- a/changelog.d/20260609_120000_lmccombes_export_make_event_store_subscriber.md
+++ b/changelog.d/20260609_120000_lmccombes_export_make_event_store_subscriber.md
@@ -1,0 +1,6 @@
+### Added
+
+- Exported `make_event_store_subscriber` from `logicblocks.event.processing` and
+  `logicblocks.event.processing.consumers`. This convenience wrapper around
+  `make_subscriber` pre-fills the `subscriber_state_converter` for the common
+  `StoredEvent` case.

--- a/src/logicblocks/event/processing/__init__.py
+++ b/src/logicblocks/event/processing/__init__.py
@@ -26,6 +26,7 @@ from .consumers import (
     EventSourceConsumer,
     EventSubscriptionConsumer,
     ProjectionEventProcessor,
+    make_event_store_subscriber,
     make_subscriber,
 )
 from .locks import InMemoryLockManager, Lock, LockManager, PostgresLockManager
@@ -114,6 +115,7 @@ __all__ = [
     "retry_execution_type_mapping",
     "error_handler_type_mappings",
     "make_event_broker",
+    "make_event_store_subscriber",
     "make_in_memory_event_broker",
     "make_postgres_event_broker",
     "make_subscriber",

--- a/src/logicblocks/event/processing/consumers/__init__.py
+++ b/src/logicblocks/event/processing/consumers/__init__.py
@@ -7,7 +7,11 @@ from .state import (
     EventCount,
     StoredEventEventConsumerStateConverter,
 )
-from .subscription import EventSubscriptionConsumer, make_subscriber
+from .subscription import (
+    EventSubscriptionConsumer,
+    make_event_store_subscriber,
+    make_subscriber,
+)
 from .types import (
     AutoCommitEventIteratorProcessor,
     EventConsumer,
@@ -29,6 +33,7 @@ __all__ = [
     "EventProcessorManager",
     "EventSourceConsumer",
     "EventSubscriptionConsumer",
+    "make_event_store_subscriber",
     "make_subscriber",
     "ManagedEventIteratorProcessor",
     "ProjectionEventProcessor",


### PR DESCRIPTION
## Summary

`make_event_store_subscriber` is defined in `processing/consumers/subscription.py` next to `make_subscriber` and is intended as a convenience wrapper for the common `StoredEvent` case — it pre-fills the now-required `subscriber_state_converter` kwarg with `StoredEventEventConsumerStateConverter()`. It just wasn't exported from the package's public API.

This PR adds it to `__all__` in both `processing.consumers` (where it's defined) and `processing` (the parent), matching the existing export pattern for `make_subscriber`.

## Why

When `make_subscriber` was generalised over arbitrary `Event` types, downstream callers using `StoredEvent` (the common case) now have to either:

1. Pass `subscriber_state_converter=StoredEventEventConsumerStateConverter()` at every call site, or
2. Reach past the public API to import `make_event_store_subscriber` from the implementation module.

Exporting the wrapper that's already implemented removes both papercuts and makes the migration to 0.1.10 cleaner for `StoredEvent` consumers.

## Changes

- `src/logicblocks/event/processing/consumers/__init__.py`: import + add to `__all__`
- `src/logicblocks/event/processing/__init__.py`: re-export + add to `__all__`
- `changelog.d/`: scriv fragment under "Added"

No behaviour change, no new tests required.