### PR TITLE
Use UNSET sentinel for NewEvent metadata default

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,9 @@ async def main():
     store = EventStore(adapter)
 
     stream = store.stream(category="profiles", stream="joe.bloggs")
-    # metadata is required; pass metadata=None when the event has no metadata
+    # metadata is optional; omit it to leave the event's metadata unset
     profile_created_event = NewEvent(name="profile-created",
-                                     payload={"name": "Joe Bloggs", "email": "joe.bloggs@example.com"},
-                                     metadata=None)
+                                     payload={"name": "Joe Bloggs", "email": "joe.bloggs@example.com"})
     date_of_birth_set_event = NewEvent(name="date-of-birth-set", payload={"dob": "1992-07-10"},
                                        metadata={"actor": "user-123"})
 
@@ -102,19 +101,27 @@ asyncio.run(main())
 
 Instead of setting `metadata` on every event, you can supply a single
 `metadata` mapping alongside `events` and have it applied to the whole batch.
-It fills only events whose `metadata is None`; per-event metadata always takes
-precedence.
+An event's `metadata` has three states:
+
+- **unset** (the default, when `metadata` is omitted) — the event takes the
+  batch metadata, or `None` if no batch metadata is supplied.
+- **an explicit value** (e.g. `metadata={"actor": "user-123"}`) — kept as-is;
+  per-event metadata always takes precedence over the batch.
+- **explicit `None`** — an opt-out: the event keeps `None` even when batch
+  metadata is supplied.
 
 ```python
 await stream.publish(
     events=[
-        NewEvent(name="profile-created", payload={...}, metadata=None),
-        NewEvent(name="date-of-birth-set", payload={...}, metadata={"actor": "user-123"}),
+        NewEvent(name="profile-created", payload={...}),                       # unset -> batch
+        NewEvent(name="date-of-birth-set", payload={...}, metadata={"actor": "user-123"}),  # kept
+        NewEvent(name="imported", payload={...}, metadata=None),               # opt-out -> None
     ],
     metadata={"actor": "service", "tenant": "acme"},
 )
-# the first event is stored with {"actor": "service", "tenant": "acme"}
-# the second keeps its own {"actor": "user-123"}
+# profile-created  -> {"actor": "service", "tenant": "acme"}
+# date-of-birth-set -> {"actor": "user-123"}
+# imported          -> None
 ```
 
 The same option is available per stream when publishing to a category via

--- a/changelog.d/20260707_162857_john.md
+++ b/changelog.d/20260707_162857_john.md
@@ -1,3 +1,8 @@
 ### Added
 
-- Added an optional batch-level `metadata` argument to `EventStream.publish`, and an optional `metadata` key to `StreamPublishDefinition` / `stream_publish_definition` (used by `EventCategory.publish`). When supplied, the batch metadata fills every event whose `metadata is None`; events that carry their own metadata are left untouched. The change is additive and backwards compatible — omitting the argument/key behaves exactly as before, with no schema change, no migration, and no breaking change. Per-event metadata always takes precedence over batch metadata.
+- Added an optional batch-level `metadata` argument to `EventStream.publish`, and an optional `metadata` key to `StreamPublishDefinition` / `stream_publish_definition` (used by `EventCategory.publish`). When supplied, the batch metadata fills every event whose metadata is _unset_; events carrying their own metadata (including an explicit `None`) are left untouched, so per-event metadata always takes precedence. Per-stream metadata is isolated in category publishes.
+- Exported an `UNSET` sentinel (and its `Unset` type) from `logicblocks.event.types`, marking an event's metadata as unspecified.
+
+### Changed
+
+- `NewEvent.metadata` is now optional and defaults to the `UNSET` sentinel. Omitting `metadata` marks the event for batch-fill (resolving to `None` when no batch metadata is supplied), whereas passing `metadata=None` explicitly opts the event out of batch-fill and stores JSON `null`. This is backwards compatible: existing callers that pass `metadata=None` continue to store `null` exactly as before, and there is no schema, migration, or adapter change.

--- a/src/logicblocks/event/store/types.py
+++ b/src/logicblocks/event/store/types.py
@@ -1,7 +1,8 @@
 from collections.abc import Sequence
-from typing import NotRequired, TypedDict
+from typing import NotRequired, TypedDict, cast
 
 from logicblocks.event.types import (
+    UNSET,
     JsonPersistable,
     JsonValue,
     NewEvent,
@@ -49,15 +50,13 @@ def resolve_batch_metadata[
     events: Sequence[NewEvent[Name, Payload, Metadata]],
     batch_metadata: Metadata | None,
 ) -> Sequence[NewEvent[Name, Payload, Metadata]]:
-    if batch_metadata is None:
-        return events
     return [
         event
-        if event.metadata is not None
+        if event.metadata is not UNSET
         else NewEvent[Name, Payload, Metadata](
             name=event.name,
             payload=event.payload,
-            metadata=batch_metadata,
+            metadata=cast(Metadata, batch_metadata),
             observed_at=event.observed_at,
             occurred_at=event.occurred_at,
         )

--- a/src/logicblocks/event/types/__init__.py
+++ b/src/logicblocks/event/types/__init__.py
@@ -13,7 +13,7 @@ from .conversion import (
     serialise_to_string,
     str_serialisation_fallback,
 )
-from .event import Event, NewEvent, StoredEvent
+from .event import UNSET, Event, NewEvent, StoredEvent, Unset
 from .functions import Applier, Converter
 from .identifier import (
     CategoryIdentifier,
@@ -70,6 +70,8 @@ __all__ = [
     "StringLoggable",
     "StringPersistable",
     "StringSerialisable",
+    "UNSET",
+    "Unset",
     "default_deserialisation_fallback",
     "default_serialisation_fallback",
     "deserialise_from_json_value",

--- a/src/logicblocks/event/types/event.py
+++ b/src/logicblocks/event/types/event.py
@@ -9,6 +9,27 @@ from .conversion import JsonPersistable, serialise_to_json_value
 from .json import JsonValue, JsonValueSerialisable
 
 
+class Unset:
+    """Sentinel marking an event's metadata as unspecified.
+
+    Distinguishes "no metadata supplied, fill from any batch default" (`UNSET`,
+    the default) from "explicitly no metadata, do not fill" (`None`).
+    """
+
+    _instance: "Unset | None" = None
+
+    def __new__(cls) -> "Unset":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "UNSET"
+
+
+UNSET = Unset()
+
+
 class Event(Protocol):
     def summarise(self) -> JsonValue:
         raise NotImplementedError
@@ -29,7 +50,7 @@ class NewEvent[Name = str, Payload = JsonValue, Metadata = JsonValue](
         *,
         name: Name,
         payload: Payload,
-        metadata: Metadata,
+        metadata: Metadata | Unset = UNSET,
         observed_at: datetime | None = None,
         occurred_at: datetime | None = None,
         clock: Clock = SystemClock(),

--- a/tests/unit/logicblocks/event/store/test_store.py
+++ b/tests/unit/logicblocks/event/store/test_store.py
@@ -639,7 +639,7 @@ class TestStreamPublishing:
         assert len(stored_events) == 1
         assert stored_events[0].metadata == metadata
 
-    async def test_batch_metadata_fills_none_events_leaving_others_untouched(
+    async def test_batch_metadata_fills_unset_events_leaving_others_untouched(
         self,
     ):
         category_name = data.random_event_category_name()
@@ -650,25 +650,42 @@ class TestStreamPublishing:
         store = EventStore(adapter=InMemoryEventStorageAdapter())
         stream = store.stream(category=category_name, stream=stream_name)
 
-        none_event = NewEvent(name="a", payload={}, metadata=None)
+        unset_event = NewEvent(name="a", payload={})
         own_event = NewEvent(name="b", payload={}, metadata=own)
 
         stored_events = await stream.publish(
-            events=[none_event, own_event], metadata=batch
+            events=[unset_event, own_event], metadata=batch
         )
 
         assert [event.metadata for event in stored_events] == [batch, own]
 
-    async def test_omitting_batch_metadata_leaves_none_events_as_none(self):
+    async def test_explicit_none_metadata_opts_out_of_batch_metadata(self):
+        category_name = data.random_event_category_name()
+        stream_name = data.random_event_stream_name()
+        batch = {"actor": "svc"}
+
+        store = EventStore(adapter=InMemoryEventStorageAdapter())
+        stream = store.stream(category=category_name, stream=stream_name)
+
+        unset_event = NewEvent(name="a", payload={})
+        opted_out_event = NewEvent(name="b", payload={}, metadata=None)
+
+        stored_events = await stream.publish(
+            events=[unset_event, opted_out_event], metadata=batch
+        )
+
+        assert [event.metadata for event in stored_events] == [batch, None]
+
+    async def test_omitting_batch_metadata_leaves_unset_events_as_none(self):
         category_name = data.random_event_category_name()
         stream_name = data.random_event_stream_name()
 
         store = EventStore(adapter=InMemoryEventStorageAdapter())
         stream = store.stream(category=category_name, stream=stream_name)
 
-        none_event = NewEvent(name="a", payload={}, metadata=None)
+        unset_event = NewEvent(name="a", payload={})
 
-        stored_events = await stream.publish(events=[none_event])
+        stored_events = await stream.publish(events=[unset_event])
 
         assert stored_events[0].metadata is None
 
@@ -1161,7 +1178,7 @@ class TestCategoryPublish:
         assert len(stored_events[stream_name]) == 1
         assert stored_events[stream_name][0].metadata == metadata
 
-    async def test_batch_metadata_fills_none_events_leaving_others_untouched(
+    async def test_batch_metadata_fills_unset_events_leaving_others_untouched(
         self,
     ):
         category_name = data.random_event_category_name()
@@ -1172,13 +1189,13 @@ class TestCategoryPublish:
         store = EventStore(adapter=InMemoryEventStorageAdapter())
         category = store.category(category=category_name)
 
-        none_event = NewEvent(name="a", payload={}, metadata=None)
+        unset_event = NewEvent(name="a", payload={})
         own_event = NewEvent(name="b", payload={}, metadata=own)
 
         stored_events = await category.publish(
             streams={
                 stream_name: stream_publish_definition(
-                    events=[none_event, own_event], metadata=batch
+                    events=[unset_event, own_event], metadata=batch
                 )
             }
         )
@@ -1186,6 +1203,30 @@ class TestCategoryPublish:
         assert [event.metadata for event in stored_events[stream_name]] == [
             batch,
             own,
+        ]
+
+    async def test_explicit_none_metadata_opts_out_of_batch_metadata(self):
+        category_name = data.random_event_category_name()
+        stream_name = data.random_event_stream_name()
+        batch = {"actor": "svc"}
+
+        store = EventStore(adapter=InMemoryEventStorageAdapter())
+        category = store.category(category=category_name)
+
+        unset_event = NewEvent(name="a", payload={})
+        opted_out_event = NewEvent(name="b", payload={}, metadata=None)
+
+        stored_events = await category.publish(
+            streams={
+                stream_name: stream_publish_definition(
+                    events=[unset_event, opted_out_event], metadata=batch
+                )
+            }
+        )
+
+        assert [event.metadata for event in stored_events[stream_name]] == [
+            batch,
+            None,
         ]
 
     async def test_batch_metadata_is_isolated_per_stream(self):
@@ -1200,15 +1241,11 @@ class TestCategoryPublish:
         stored_events = await category.publish(
             streams={
                 filled_stream_name: stream_publish_definition(
-                    events=[
-                        NewEvent[str, JsonValue, JsonValue](
-                            name="a", payload={}, metadata=None
-                        )
-                    ],
+                    events=[NewEvent(name="a", payload={})],
                     metadata=batch,
                 ),
                 untouched_stream_name: stream_publish_definition(
-                    events=[NewEvent(name="b", payload={}, metadata=None)],
+                    events=[NewEvent(name="b", payload={})],
                 ),
             }
         )
@@ -1216,7 +1253,7 @@ class TestCategoryPublish:
         assert stored_events[filled_stream_name][0].metadata == batch
         assert stored_events[untouched_stream_name][0].metadata is None
 
-    async def test_definition_without_metadata_leaves_none_events_as_none(
+    async def test_definition_without_metadata_leaves_unset_events_as_none(
         self,
     ):
         category_name = data.random_event_category_name()
@@ -1228,7 +1265,7 @@ class TestCategoryPublish:
         stored_events = await category.publish(
             streams={
                 stream_name: stream_publish_definition(
-                    events=[NewEvent(name="a", payload={}, metadata=None)],
+                    events=[NewEvent(name="a", payload={})],
                 )
             }
         )
@@ -1245,7 +1282,7 @@ class TestCategoryPublish:
         await category.publish(
             streams={
                 stream_name: stream_publish_definition(
-                    events=[NewEvent(name="seed", payload={}, metadata=None)],
+                    events=[NewEvent(name="seed", payload={})],
                 )
             }
         )
@@ -1254,11 +1291,7 @@ class TestCategoryPublish:
             await category.publish(
                 streams={
                     stream_name: stream_publish_definition(
-                        events=[
-                            NewEvent[str, JsonValue, JsonValue](
-                                name="a", payload={}, metadata=None
-                            )
-                        ],
+                        events=[NewEvent(name="a", payload={})],
                         condition=conditions.stream_is_empty(),
                         metadata={"actor": "svc"},
                     )
@@ -1276,11 +1309,7 @@ class TestCategoryPublish:
         stored_events = await category.publish(
             streams={
                 stream_name: stream_publish_definition(
-                    events=[
-                        NewEvent[str, JsonValue, JsonValue](
-                            name="a", payload={}, metadata=None
-                        )
-                    ],
+                    events=[NewEvent(name="a", payload={})],
                     condition=conditions.stream_is_empty(),
                     metadata=batch,
                 )

--- a/tests/unit/logicblocks/event/store/test_types.py
+++ b/tests/unit/logicblocks/event/store/test_types.py
@@ -7,26 +7,20 @@ from logicblocks.event.testing import NewEventBuilder
 from logicblocks.event.types import NewEvent
 
 
-def new_event_without_metadata(name: str = "event") -> NewEvent:
+def new_event_with_unset_metadata(name: str = "event") -> NewEvent:
+    return NewEvent(name=name, payload={"value": name})
+
+
+def new_event_with_explicit_none_metadata(name: str = "event") -> NewEvent:
     return NewEvent(name=name, payload={"value": name}, metadata=None)
 
 
 class TestResolveBatchMetadata:
-    def test_returns_events_unchanged_when_batch_metadata_is_none(self):
-        events = [
-            new_event_without_metadata("event-1"),
-            NewEventBuilder().with_metadata({"a": "b"}).build(),
-        ]
-
-        resolved = resolve_batch_metadata(events, None)
-
-        assert resolved == events
-
-    def test_fills_none_event_with_batch_metadata_preserving_other_fields(
+    def test_fills_unset_event_with_batch_metadata_preserving_other_fields(
         self,
     ):
         batch = {"actor": "svc"}
-        event = new_event_without_metadata()
+        event = new_event_with_unset_metadata()
 
         resolved = resolve_batch_metadata([event], batch)
 
@@ -34,6 +28,20 @@ class TestResolveBatchMetadata:
             name=event.name,
             payload=event.payload,
             metadata=batch,
+            observed_at=event.observed_at,
+            occurred_at=event.occurred_at,
+        )
+        assert resolved == [expected]
+
+    def test_fills_unset_event_with_none_when_no_batch_metadata(self):
+        event = new_event_with_unset_metadata()
+
+        resolved = resolve_batch_metadata([event], None)
+
+        expected = NewEvent(
+            name=event.name,
+            payload=event.payload,
+            metadata=None,
             observed_at=event.observed_at,
             occurred_at=event.occurred_at,
         )
@@ -47,36 +55,47 @@ class TestResolveBatchMetadata:
 
         assert resolved == [event]
 
-    def test_fills_only_none_events_in_mixed_batch(self):
+    def test_treats_explicit_none_as_opt_out_from_batch_metadata(self):
+        event = new_event_with_explicit_none_metadata()
+
+        resolved = resolve_batch_metadata([event], {"actor": "svc"})
+
+        assert resolved == [event]
+        assert resolved[0].metadata is None
+
+    def test_fills_only_unset_events_in_mixed_batch(self):
         batch = {"actor": "svc"}
-        none_event = new_event_without_metadata()
+        unset_event = new_event_with_unset_metadata()
+        opted_out_event = new_event_with_explicit_none_metadata("opted-out")
         own_event = NewEventBuilder().with_metadata({"actor": "own"}).build()
 
-        resolved = resolve_batch_metadata([none_event, own_event], batch)
+        resolved = resolve_batch_metadata(
+            [unset_event, opted_out_event, own_event], batch
+        )
 
         expected_filled = NewEvent(
-            name=none_event.name,
-            payload=none_event.payload,
+            name=unset_event.name,
+            payload=unset_event.payload,
             metadata=batch,
-            observed_at=none_event.observed_at,
-            occurred_at=none_event.occurred_at,
+            observed_at=unset_event.observed_at,
+            occurred_at=unset_event.occurred_at,
         )
-        assert resolved == [expected_filled, own_event]
+        assert resolved == [expected_filled, opted_out_event, own_event]
 
     def test_returns_empty_list_for_empty_events(self):
         assert resolve_batch_metadata([], {"actor": "svc"}) == []
 
-    def test_fills_none_event_with_empty_mapping_batch_metadata(self):
-        none_event = new_event_without_metadata()
+    def test_fills_unset_event_with_empty_mapping_batch_metadata(self):
+        unset_event = new_event_with_unset_metadata()
 
-        resolved = resolve_batch_metadata([none_event], {})
+        resolved = resolve_batch_metadata([unset_event], {})
 
         expected = NewEvent(
-            name=none_event.name,
-            payload=none_event.payload,
+            name=unset_event.name,
+            payload=unset_event.payload,
             metadata={},
-            observed_at=none_event.observed_at,
-            occurred_at=none_event.occurred_at,
+            observed_at=unset_event.observed_at,
+            occurred_at=unset_event.occurred_at,
         )
         assert resolved == [expected]
 

--- a/tests/unit/logicblocks/event/types/test_event.py
+++ b/tests/unit/logicblocks/event/types/test_event.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta, tzinfo
 
 import pytest
 
-from logicblocks.event.types import NewEvent, StoredEvent
+from logicblocks.event.types import UNSET, NewEvent, StoredEvent
 from logicblocks.event.utils.clock import StaticClock
 
 
@@ -24,6 +24,20 @@ class VerifyingStaticClock(StaticClock):
 
 
 class TestNewEvent:
+    def test_defaults_metadata_to_unset_when_omitted(self):
+        event = NewEvent(name="something-happened", payload={"foo": "bar"})
+
+        assert event.metadata is UNSET
+
+    def test_uses_metadata_when_provided(self):
+        event = NewEvent(
+            name="something-happened",
+            payload={"foo": "bar"},
+            metadata={"actor": "svc"},
+        )
+
+        assert event.metadata == {"actor": "svc"}
+
     def test_uses_occurred_at_when_provided(self):
         occurred_at = datetime.now(UTC)
         event = NewEvent(


### PR DESCRIPTION
Stacked on top of #118. Targets `batch-level-publish-metadata` so the diff shows only the sentinel change.

## Motivation

In #118, an event's absent metadata and a deliberate "no metadata" are both `None`, so there is **no way to keep an event's metadata `None` while its siblings take the batch default** in the same `publish(...)` call (called out under *"What We're NOT Doing"* in the plan).

There is no opaque-sentinel precedent in `event.store` today (the house style is meaningful `None` and typed null-objects like `NoCondition()`), but introducing one here is the only way to give `metadata` a third state and resolve that limitation.

## Change

`NewEvent.metadata` now defaults to an `UNSET` sentinel, giving three states:

| `metadata` | with batch `{x}` | without batch |
|---|---|---|
| omitted (**`UNSET`**) | `{x}` (filled) | `None` |
| `None` (explicit) | **`None`** (opt-out) | `None` |
| `{y}` | `{y}` | `{y}` |

- `UNSET`/`Unset` exported from `logicblocks.event.types`.
- Resolver keys off `is not UNSET` and **always runs** (so a stray `UNSET` can never reach serialisation), collapsing `UNSET → batch or None`.
- **Sentinel is contained to the constructor.** The `NewEvent.metadata` *field* stays typed `Metadata`; only `__init__` accepts `Metadata | Unset`. This keeps the sentinel out of every downstream reader (both adapters, the builders) that forwards metadata into `StoredEvent`.

## Compatibility

Backwards compatible: callers passing `metadata=None` still store JSON `null` exactly as before. No schema, migration, or adapter change. This does re-loosen the required-`metadata` decision from #116 (`metadata` becomes optional again) — flagged for reviewer judgement.

## Testing

- Resolver + stream + category tests rewritten for the three-state semantics (unset fills, explicit-`None` opts out, per-event/per-stream precedence).
- New `NewEvent` tests pin the `UNSET` default.
- Full build green: `mise run` — lint, format, types, unit (1710), integration (134), component (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)