### PR TITLE
Assert absent-field filter behaviour across projection adapters

### DIFF
--- a/tests/integration/logicblocks/event/projection/store/adapters/test_postgres.py
+++ b/tests/integration/logicblocks/event/projection/store/adapters/test_postgres.py
@@ -2,9 +2,14 @@ import os
 from typing import Sequence
 
 import pytest_asyncio
+import pytest
+
 from logicblocks.event.testcases.projection.store.adapters import (
     ProjectionStorageAdapterCases,
+    Thing,
+    ThingProjectionBuilder,
 )
+from logicblocks.event.query import FilterClause, Operator, Path, Search
 from logicblocks.event.testsupport import (
     clear_table,
     connection_pool,
@@ -90,3 +95,50 @@ class TestPostgresProjectionStorageAdapterCommonCases(
         self, *, adapter: ProjectionStorageAdapter
     ) -> Sequence[Projection[JsonValue, JsonValue]]:
         return await read_projections(self.pool, "projections")
+
+
+class TestPostgresProjectionStorageAdapterAbsentFieldBehaviour:
+    """Asserts the DESIRED behaviour when filtering on an absent field.
+
+    We have chosen "raise a ``ValueError``" as the unified behaviour, matching
+    the in-memory adapter (see the mirror test
+    ``TestInMemoryProjectionStorageAdapterAbsentFieldBehaviour`` in
+    ``tests/unit/.../adapters/test_memory.py``). The Postgres adapter currently
+    silently excludes the projection instead, so this test is EXPECTED TO FAIL
+    until the adapter is updated to raise on an absent field.
+    """
+
+    pool: AsyncConnectionPool[AsyncConnection]
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def store_connection_pool(self, open_connection_pool):
+        self.pool = open_connection_pool
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def reinitialise_storage(self, open_connection_pool):
+        await enable_extension(open_connection_pool, "pg_trgm")
+        await drop_table(open_connection_pool, "projections")
+        await create_table(open_connection_pool, "projections")
+
+    @pytest.mark.parametrize(
+        "operator", [Operator.EQUAL, Operator.NOT_EQUAL]
+    )
+    async def test_filtering_on_absent_field_raises(
+        self, operator: Operator
+    ) -> None:
+        adapter = PostgresProjectionStorageAdapter(connection_source=self.pool)
+        await adapter.save(
+            projection=ThingProjectionBuilder()
+            .with_state(Thing(value_1=1))
+            .build()
+        )
+
+        with pytest.raises(ValueError):
+            await adapter.find_many(
+                search=Search(
+                    filters=[
+                        FilterClause(operator, Path("state", "value_5"), 42)
+                    ]
+                ),
+                state_type=Thing,
+            )

--- a/tests/integration/logicblocks/event/projection/store/adapters/test_postgres.py
+++ b/tests/integration/logicblocks/event/projection/store/adapters/test_postgres.py
@@ -1,15 +1,13 @@
 import os
 from typing import Sequence
 
-import pytest_asyncio
 import pytest
-
+import pytest_asyncio
 from logicblocks.event.testcases.projection.store.adapters import (
     ProjectionStorageAdapterCases,
     Thing,
     ThingProjectionBuilder,
 )
-from logicblocks.event.query import FilterClause, Operator, Path, Search
 from logicblocks.event.testsupport import (
     clear_table,
     connection_pool,
@@ -28,6 +26,7 @@ from logicblocks.event.projection.store import ProjectionStorageAdapter
 from logicblocks.event.projection.store.adapters import (
     PostgresProjectionStorageAdapter,
 )
+from logicblocks.event.query import FilterClause, Operator, Path, Search
 from logicblocks.event.types import JsonValue, Projection, identifier
 
 connection_settings = ConnectionSettings(
@@ -120,9 +119,7 @@ class TestPostgresProjectionStorageAdapterAbsentFieldBehaviour:
         await drop_table(open_connection_pool, "projections")
         await create_table(open_connection_pool, "projections")
 
-    @pytest.mark.parametrize(
-        "operator", [Operator.EQUAL, Operator.NOT_EQUAL]
-    )
+    @pytest.mark.parametrize("operator", [Operator.EQUAL, Operator.NOT_EQUAL])
     async def test_filtering_on_absent_field_raises(
         self, operator: Operator
     ) -> None:

--- a/tests/unit/logicblocks/event/projection/store/adapters/test_memory.py
+++ b/tests/unit/logicblocks/event/projection/store/adapters/test_memory.py
@@ -1,12 +1,16 @@
 from collections.abc import Sequence
 
+import pytest
+
 from logicblocks.event.testcases.projection.store.adapters import (
     ProjectionStorageAdapterCases,
+    Thing,
+    ThingProjectionBuilder,
 )
 
 from logicblocks.event.projection import InMemoryProjectionStorageAdapter
 from logicblocks.event.projection.store import ProjectionStorageAdapter
-from logicblocks.event.query import Search
+from logicblocks.event.query import FilterClause, Operator, Path, Search
 from logicblocks.event.types import JsonValue, Projection
 
 
@@ -23,3 +27,40 @@ class TestInMemoryProjectionStorageAdapter(ProjectionStorageAdapterCases):
         adapter: ProjectionStorageAdapter,
     ) -> Sequence[Projection[JsonValue]]:
         return await adapter.find_many(search=Search())
+
+
+class TestInMemoryProjectionStorageAdapterAbsentFieldBehaviour:
+    """Asserts the DESIRED behaviour when filtering on an absent field.
+
+    We have chosen "raise a ``ValueError``" as the unified behaviour. This
+    adapter already behaves this way; the Postgres adapter does NOT (it
+    silently excludes the projection), so its mirror test
+    ``TestPostgresProjectionStorageAdapterAbsentFieldBehaviour`` in
+    ``tests/integration/.../adapters/test_postgres.py`` is expected to fail
+    until the adapter is aligned.
+    """
+
+    @pytest.mark.parametrize(
+        "operator", [Operator.EQUAL, Operator.NOT_EQUAL]
+    )
+    async def test_filtering_on_absent_field_raises(
+        self, operator: Operator
+    ) -> None:
+        adapter = InMemoryProjectionStorageAdapter()
+        await adapter.save(
+            projection=ThingProjectionBuilder()
+            .with_state(Thing(value_1=1))
+            .build()
+        )
+
+        with pytest.raises(ValueError):
+            await adapter.find_many(
+                search=Search(
+                    filters=[
+                        FilterClause(
+                            operator, Path("state", "value_5"), 42
+                        )
+                    ]
+                ),
+                state_type=Thing,
+            )

--- a/tests/unit/logicblocks/event/projection/store/adapters/test_memory.py
+++ b/tests/unit/logicblocks/event/projection/store/adapters/test_memory.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence
 
 import pytest
-
 from logicblocks.event.testcases.projection.store.adapters import (
     ProjectionStorageAdapterCases,
     Thing,
@@ -40,9 +39,7 @@ class TestInMemoryProjectionStorageAdapterAbsentFieldBehaviour:
     until the adapter is aligned.
     """
 
-    @pytest.mark.parametrize(
-        "operator", [Operator.EQUAL, Operator.NOT_EQUAL]
-    )
+    @pytest.mark.parametrize("operator", [Operator.EQUAL, Operator.NOT_EQUAL])
     async def test_filtering_on_absent_field_raises(
         self, operator: Operator
     ) -> None:
@@ -57,9 +54,7 @@ class TestInMemoryProjectionStorageAdapterAbsentFieldBehaviour:
             await adapter.find_many(
                 search=Search(
                     filters=[
-                        FilterClause(
-                            operator, Path("state", "value_5"), 42
-                        )
+                        FilterClause(operator, Path("state", "value_5"), 42)
                     ]
                 ),
                 state_type=Thing,


### PR DESCRIPTION
## Why

Filtering a projection on a field that is **entirely absent** behaves differently between the two storage adapters:

| Absent-field filter | In-memory | Postgres |
|---|---|---|
| `EQUAL value_5, 42` | raises `ValueError` | silently returns `[]` |
| `NOT_EQUAL value_5, 42` | raises `ValueError` | silently returns `[]` |

The divergence applies to **any** operator on an absent key, not just `NOT_EQUAL`, and neither behaviour was previously tested. This breaks the substitutability of the in-memory adapter as a fake for Postgres.

## What

Picks a lane — **raise `ValueError` on an absent field** — and pins it with a pair of mirror tests, one per adapter:

- `TestInMemoryProjectionStorageAdapterAbsentFieldBehaviour` — **passes** (already conformant).
- `TestPostgresProjectionStorageAdapterAbsentFieldBehaviour` — **fails intentionally**, exposing the gap to be fixed in the Postgres adapter.

Both are parametrized over `EQUAL` and `NOT_EQUAL` and cross-reference each other in their docstrings.

## Note

This is a **draft** raising the question for maintainers: is "raise" the behaviour we want, or should the in-memory adapter be relaxed to match Postgres's silent exclusion instead? The Postgres test is deliberately red until that's decided — it will fail `test:integration` / the full build in CI. If we'd rather keep CI green while tracking the gap, the failing test can be marked `xfail(strict=True)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)